### PR TITLE
Add CDN cache invalidation step to home-plant-tracker apply workflow

### DIFF
--- a/.github/workflows/home-plant-tracker-apply.yml
+++ b/.github/workflows/home-plant-tracker-apply.yml
@@ -55,8 +55,31 @@ jobs:
             -input=false \
             -auto-approve
 
-  verify:
+  invalidate-cdn:
     needs: apply
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: home-plant-tracker-lcd
+      URL_MAP: plant-tracker-url-map-prod
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.HOME_PLANT_TRACKER_WIF_PROVIDER }}
+          service_account: ${{ secrets.HOME_PLANT_TRACKER_SA_EMAIL }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Invalidate Cloud CDN cache
+        run: |
+          gcloud compute url-maps invalidate-cdn-cache "$URL_MAP" \
+            --project="$PROJECT_ID" \
+            --path="/*" \
+            --async
+
+  verify:
+    needs: [apply, invalidate-cdn]
+    if: always() && needs.apply.result == 'success'
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: home-plant-tracker-lcd


### PR DESCRIPTION
The app repo's CDN invalidation was failing due to a URL map name mismatch
(vars.ENVIRONMENT resolving to wrong value). Moving the invalidation into
the infra apply workflow ensures it uses the correct URL map name
(plant-tracker-url-map-prod) and runs with the deployer SA that already
has compute.admin permissions.

The verify job now depends on both apply and invalidate-cdn, but uses
if: always() so verification still runs even if invalidation fails.

https://claude.ai/code/session_01HYSh5DFkeN6SHKMMGoYjiw