### PR TITLE
feat(finance-doctor): enable Firebase + Firestore rules + Functions runtime

### DIFF
--- a/projects/finance-doctor/dns.tf
+++ b/projects/finance-doctor/dns.tf
@@ -2,10 +2,19 @@
 # credentials are stored in state or config.
 provider "cloudflare" {}
 
-# Custom domain DNS is not used — Cloud Run domain mapping is unsupported in
-# australia-southeast1. The app is served directly via the Cloud Run URL:
-#   https://finance-doctor-ws5d6symma-ts.a.run.app
-#
-# To add a custom domain later, either:
-#   1. Move Cloud Run to a region that supports domain mapping (e.g. us-central1)
-#   2. Add a GCP load balancer with a managed SSL certificate
+data "cloudflare_zone" "lopezcloud" {
+  name = "lopezcloud.dev"
+}
+
+# Firebase Hosting custom domain — DNS-only (grey cloud) so Firebase
+# provides its own CDN and SSL. Production traffic does not move to this
+# record until #54 cuts over; until then Cloud Run continues to serve the
+# app at its *.run.app URL.
+resource "cloudflare_record" "finance" {
+  zone_id = data.cloudflare_zone.lopezcloud.id
+  name    = "finance"
+  type    = "CNAME"
+  content = "${google_firebase_hosting_site.app.site_id}.web.app"
+  proxied = false
+  ttl     = 3600
+}

--- a/projects/finance-doctor/firebase.tf
+++ b/projects/finance-doctor/firebase.tf
@@ -1,0 +1,93 @@
+# ── Firebase Project ──────────────────────────────────────────────────────────
+# Initialises Firebase on the GCP project. Required before any Firebase
+# resources (Hosting, Functions, Auth) can be created.
+
+resource "google_firebase_project" "default" {
+  provider = google-beta
+  project  = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+# ── Firebase Hosting ──────────────────────────────────────────────────────────
+# Will serve the static-exported Next.js app once the app-side migration lands.
+# Until then, Cloud Run remains the production frontend.
+
+resource "google_firebase_hosting_site" "app" {
+  provider = google-beta
+  project  = var.project_id
+  site_id  = var.project_id # finance-doctor-lcd → finance-doctor-lcd.web.app
+
+  depends_on = [google_firebase_project.default]
+}
+
+resource "google_firebase_hosting_custom_domain" "app" {
+  provider      = google-beta
+  project       = var.project_id
+  site_id       = google_firebase_hosting_site.app.site_id
+  custom_domain = var.domain # finance.lopezcloud.dev
+
+  wait_dns_verification = false
+}
+
+# ── Firestore Security Rules ──────────────────────────────────────────────────
+# Establishes default-deny with per-user access scoped by request.auth.uid.
+# App-side migrations (#49–#51) will refine these rules as each collection
+# moves to the client SDK.
+
+resource "google_firebaserules_ruleset" "firestore" {
+  project = var.project_id
+
+  source {
+    files {
+      name    = "firestore.rules"
+      content = file("${path.module}/firestore.rules")
+    }
+  }
+
+  depends_on = [
+    google_firestore_database.default,
+    google_project_service.apis,
+  ]
+}
+
+resource "google_firebaserules_release" "firestore" {
+  project      = var.project_id
+  name         = "cloud.firestore"
+  ruleset_name = google_firebaserules_ruleset.firestore.name
+
+  lifecycle {
+    replace_triggered_by = [google_firebaserules_ruleset.firestore]
+  }
+}
+
+# ── Functions Runtime Service Account ─────────────────────────────────────────
+# Used by Callable Cloud Functions (Gemini proxies, etc.) once #52 lands.
+# Created up-front so app-side work in later issues has an identity to target.
+
+resource "google_service_account" "functions_runtime" {
+  account_id   = "${local.app_name}-functions"
+  display_name = "Finance Doctor Cloud Functions Runtime"
+  description  = "Service account for Finance Doctor Callable Cloud Functions"
+  project      = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_project_iam_member" "functions_runtime_firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.functions_runtime.email}"
+}
+
+resource "google_project_iam_member" "functions_runtime_vertex_ai" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.functions_runtime.email}"
+}
+
+resource "google_project_iam_member" "functions_runtime_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.functions_runtime.email}"
+}

--- a/projects/finance-doctor/firestore.rules
+++ b/projects/finance-doctor/firestore.rules
@@ -1,0 +1,18 @@
+rules_version = '2';
+
+// Default-deny baseline. Per-collection rules for expenses, investments,
+// family-members, and category-rules are added as each collection moves to
+// the client SDK in issues #49–#51. The baseline pattern is user-scoped
+// subcollections under /users/{uid}/, keyed by request.auth.uid.
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/{collection}/{docId} {
+      allow read, write: if request.auth != null
+        && request.auth.uid == userId;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/projects/finance-doctor/iam.tf
+++ b/projects/finance-doctor/iam.tf
@@ -45,6 +45,10 @@ locals {
     "roles/resourcemanager.projectIamAdmin",
     "roles/datastore.owner",
     "roles/appengine.appAdmin",
+    "roles/firebase.admin",
+    "roles/firebasehosting.admin",
+    "roles/cloudfunctions.admin",
+    "roles/firebaserules.admin",
   ]
 }
 

--- a/projects/finance-doctor/main.tf
+++ b/projects/finance-doctor/main.tf
@@ -37,6 +37,11 @@ resource "google_project_service" "apis" {
     "people.googleapis.com",
     "firestore.googleapis.com",
     "aiplatform.googleapis.com",
+    "firebase.googleapis.com",
+    "firebasehosting.googleapis.com",
+    "firebaserules.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "identitytoolkit.googleapis.com",
   ])
 
   project            = var.project_id


### PR DESCRIPTION
## Summary
- Lays Terraform foundation for the Firebase-native migration (#45). Cloud Run keeps serving production until #54 cuts over.
- Adds Firebase project, Hosting site `finance-doctor-lcd.web.app`, custom domain `finance.lopezcloud.dev`, default-deny `firestore.rules`, and a `finance-doctor-functions` runtime SA.
- Extends deployer SA with `firebase.admin`, `firebasehosting.admin`, `cloudfunctions.admin`, `firebaserules.admin`; replaces the old Cloud Run domain-mapping stub in `dns.tf` with a Cloudflare CNAME `finance` → `finance-doctor-lcd.web.app` (DNS-only).

## Manual bootstrap (one-off, documented in #46)
CI deployer SA can't grant itself Firebase perms on first run — run once as admin:
```
gcloud projects add-iam-policy-binding finance-doctor-lcd \
  --member='serviceAccount:finance-doctor-deployer@finance-doctor-lcd.iam.gserviceaccount.com' \
  --role='roles/firebase.admin' --condition=None
# repeat for firebasehosting.admin, cloudfunctions.admin, firebaserules.admin
```

## Test plan
- [ ] `terraform plan` green in CI (plan workflow posts comment)
- [ ] After merge + apply, `curl https://finance-doctor-lcd.web.app` returns Firebase's default landing page
- [ ] `dig finance.lopezcloud.dev` resolves to `finance-doctor-lcd.web.app`
- [ ] Cloud Run service for finance-doctor remains serving (unchanged by this PR)

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)