### PR TITLE
feat(finance-doctor): register Firebase Web App and publish config secrets

### DIFF
--- a/projects/finance-doctor/firebase.tf
+++ b/projects/finance-doctor/firebase.tf
@@ -30,6 +30,27 @@ resource "google_firebase_hosting_custom_domain" "app" {
   wait_dns_verification = false
 }
 
+# ── Firebase Web App ──────────────────────────────────────────────────────────
+# Registers a Firebase Web App so the browser SDK can authenticate and read
+# Firestore. Config (api_key, auth_domain, app_id) is pulled via the data
+# source and published to Secret Manager in firebase_secrets.tf so the app
+# build can fetch it at deploy time.
+
+resource "google_firebase_web_app" "app" {
+  provider        = google-beta
+  project         = var.project_id
+  display_name    = "Finance Doctor"
+  deletion_policy = "DELETE"
+
+  depends_on = [google_firebase_project.default]
+}
+
+data "google_firebase_web_app_config" "app" {
+  provider   = google-beta
+  project    = var.project_id
+  web_app_id = google_firebase_web_app.app.app_id
+}
+
 # ── Firestore Security Rules ──────────────────────────────────────────────────
 # Establishes default-deny with per-user access scoped by request.auth.uid.
 # App-side migrations (#49–#51) will refine these rules as each collection

--- a/projects/finance-doctor/firebase_secrets.tf
+++ b/projects/finance-doctor/firebase_secrets.tf
@@ -1,0 +1,43 @@
+# Publishes the Firebase Web App config to Secret Manager so the app-repo
+# build/deploy workflow can fetch it at build time. api_key and auth_domain
+# are semi-sensitive; project_id and app_id are public, but keeping all four
+# in Secret Manager gives the deploy workflow one consistent fetch path.
+
+locals {
+  firebase_web_secrets = {
+    "firebase-web-api-key"     = data.google_firebase_web_app_config.app.api_key
+    "firebase-web-auth-domain" = data.google_firebase_web_app_config.app.auth_domain
+    "firebase-web-project-id"  = var.project_id
+    "firebase-web-app-id"      = google_firebase_web_app.app.app_id
+  }
+}
+
+resource "google_secret_manager_secret" "firebase_web" {
+  for_each = local.firebase_web_secrets
+
+  project   = var.project_id
+  secret_id = each.key
+  labels    = local.labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "firebase_web" {
+  for_each = local.firebase_web_secrets
+
+  secret      = google_secret_manager_secret.firebase_web[each.key].id
+  secret_data = each.value
+}
+
+resource "google_secret_manager_secret_iam_member" "firebase_web_deployer" {
+  for_each = local.firebase_web_secrets
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.firebase_web[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.github_deployer.email}"
+}


### PR DESCRIPTION
## Summary
- Registers a `google_firebase_web_app` on finance-doctor-lcd and reads its config via the `google_firebase_web_app_config` data source.
- Publishes the 4 config values (`api_key`, `auth_domain`, `project_id`, `app_id`) to Secret Manager as `firebase-web-*` so the app-repo deploy workflow has a single fetch path instead of a manual copy step.
- Grants `roles/secretmanager.secretAccessor` on each secret to the `finance-doctor-deployer` SA.

Plan-on-PR will fail WIF auth like always; merge to master runs the real apply.

## Test plan
- [ ] Apply on master runs green
- [ ] `gcloud secrets list --project=finance-doctor-lcd` shows 4 `firebase-web-*` entries
- [ ] `gcloud firebase apps sdkconfig WEB <appId> --project=finance-doctor-lcd` (or console) shows the registered Web App
- [ ] App-repo build/deploy no longer warns `[firebase] ... env vars are not set`

Part of #47 (app-side Firebase SDK wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)