### PR TITLE
fix(finance-doctor): unblock Firebase Functions deploy

### DIFF
--- a/projects/finance-doctor/iam.tf
+++ b/projects/finance-doctor/iam.tf
@@ -1,3 +1,9 @@
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
 locals {
   operator_member = length(regexall("^serviceAccount:", var.terraform_operator_email)) > 0 ? var.terraform_operator_email : "user:${var.terraform_operator_email}"
 
@@ -133,4 +139,24 @@ resource "google_service_account_iam_member" "github_app_wif_binding" {
   service_account_id = google_service_account.github_deployer.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_app.name}/attribute.repository/${var.github_org}/${var.app_github_repo}"
+}
+
+# ── Functions Deploy — Act-as bindings ────────────────────────────────────────
+# firebase deploy --only functions needs two things beyond the deployer's
+# project-level roles:
+#   1. The deployer SA must be able to deploy a function that *runs as* the
+#      finance-doctor-functions runtime SA (iam.serviceAccountUser, SA-scoped).
+#   2. The Cloud Build default compute SA builds the function image and must
+#      likewise be able to impersonate the runtime SA.
+
+resource "google_service_account_iam_member" "deployer_act_as_functions_runtime" {
+  service_account_id = google_service_account.functions_runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+resource "google_service_account_iam_member" "cloudbuild_act_as_functions_runtime" {
+  service_account_id = google_service_account.functions_runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${data.google_compute_default_service_account.default.email}"
 }

--- a/projects/finance-doctor/main.tf
+++ b/projects/finance-doctor/main.tf
@@ -31,6 +31,7 @@ resource "google_project_service" "apis" {
     "run.googleapis.com",
     "artifactregistry.googleapis.com",
     "cloudbuild.googleapis.com",
+    "cloudbilling.googleapis.com",
     "secretmanager.googleapis.com",
     "monitoring.googleapis.com",
     "billingbudgets.googleapis.com",
@@ -40,7 +41,10 @@ resource "google_project_service" "apis" {
     "firebase.googleapis.com",
     "firebasehosting.googleapis.com",
     "firebaserules.googleapis.com",
+    "firebaseextensions.googleapis.com",
     "cloudfunctions.googleapis.com",
+    "eventarc.googleapis.com",
+    "pubsub.googleapis.com",
     "identitytoolkit.googleapis.com",
   ])
 


### PR DESCRIPTION
## Summary

- Enable `cloudbilling`, `eventarc`, `pubsub`, `firebaseextensions` APIs — `firebase deploy --only functions` probes Cloud Billing first and 403'd on the missing API enablement.
- Grant deployer SA `roles/iam.serviceAccountUser` on the `finance-doctor-functions` runtime SA (SA-scoped) so it can deploy functions that run as that identity.
- Grant the default compute SA (used by Cloud Build to build the function image) `roles/iam.serviceAccountUser` on the runtime SA.

Closes the deploy half of finance-doctor #52. #46 remains the foundation; runtime SA perms (datastore/aiplatform/secretAccessor) from #46 are not duplicated.

## Test plan

- [ ] platform-infra plan workflow is clean for finance-doctor
- [ ] After merge, apply workflow turns green
- [ ] Re-run finance-doctor Build & Deploy on master — the Deploy Cloud Functions step succeeds (7 functions in australia-southeast1)
- [ ] `gcloud functions list --region=australia-southeast1 --project=finance-doctor-lcd` shows: adviceChat, dashboardTips, taxAdvice, investmentsAdvice, expensesImport, expensesMigrate, expensesReanalyse

🤖 Generated with [Claude Code](https://claude.com/claude-code)