### PR TITLE
fix(finance-doctor): enable compute.googleapis.com

### DIFF
--- a/projects/finance-doctor/main.tf
+++ b/projects/finance-doctor/main.tf
@@ -28,6 +28,7 @@ resource "google_project_service" "apis" {
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "sts.googleapis.com",
+    "compute.googleapis.com",
     "run.googleapis.com",
     "artifactregistry.googleapis.com",
     "cloudbuild.googleapis.com",


### PR DESCRIPTION
## Summary

Follow-up to #25. The apply failed on `data.google_compute_default_service_account.default` because Compute Engine API wasn't enabled on finance-doctor-lcd — the data source requires it to resolve the default compute SA. Adding `compute.googleapis.com` to the enabled-APIs list fixes the 403 and creates the default SA we grant `iam.serviceAccountUser` to.

## Test plan

- [ ] platform-infra apply workflow turns green post-merge
- [ ] Re-run finance-doctor Build & Deploy — Deploy Cloud Functions step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)