### PR TITLE
fix(finance-doctor): resolve default compute SA by project number

### DIFF
--- a/projects/finance-doctor/iam.tf
+++ b/projects/finance-doctor/iam.tf
@@ -1,10 +1,10 @@
-data "google_compute_default_service_account" "default" {
-  project = var.project_id
-
-  depends_on = [google_project_service.apis]
-}
-
 locals {
+  # Cloud Build's default builder identity on Cloud Functions v2 / Firebase
+  # Functions deploys. Constructed from the project number to avoid needing
+  # compute.projects.get on the deployer SA (the data source equivalent would
+  # require it).
+  default_compute_sa_email = "${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+
   operator_member = length(regexall("^serviceAccount:", var.terraform_operator_email)) > 0 ? var.terraform_operator_email : "user:${var.terraform_operator_email}"
 
   operator_roles = [
@@ -158,5 +158,5 @@ resource "google_service_account_iam_member" "deployer_act_as_functions_runtime"
 resource "google_service_account_iam_member" "cloudbuild_act_as_functions_runtime" {
   service_account_id = google_service_account.functions_runtime.name
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  member             = "serviceAccount:${local.default_compute_sa_email}"
 }


### PR DESCRIPTION
## Summary

Follow-up to #25/#26. Apply failed on `data.google_compute_default_service_account.default` with a 403 — the deployer SA lacks `compute.projects.get`. The default compute SA email is deterministic (`<project-number>-compute@developer.gserviceaccount.com`), so construct it from `data.google_project.project.number` instead of reading it via the compute data source. No new IAM needed.

## Test plan

- [ ] platform-infra apply workflow turns green
- [ ] Re-run finance-doctor Build & Deploy — Deploy Cloud Functions step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)