### PR TITLE
fix(finance-doctor): grant cloudbuild.builds.builder to default compute SA

### DIFF
--- a/projects/finance-doctor/iam.tf
+++ b/projects/finance-doctor/iam.tf
@@ -160,3 +160,13 @@ resource "google_service_account_iam_member" "cloudbuild_act_as_functions_runtim
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.default_compute_sa_email}"
 }
+
+# Google stopped auto-granting roles/cloudbuild.builds.builder to the default
+# compute SA on new projects in late 2024. Without it, the 2nd-gen Cloud
+# Functions build step fails on first deploy with "missing permission on the
+# build service account".
+resource "google_project_iam_member" "default_compute_sa_cloudbuild_builder" {
+  project = var.project_id
+  role    = "roles/cloudbuild.builds.builder"
+  member  = "serviceAccount:${local.default_compute_sa_email}"
+}


### PR DESCRIPTION
## Summary

2nd-gen Cloud Functions build their container via Cloud Build running as the default compute SA. Google stopped auto-granting `roles/cloudbuild.builds.builder` on newly-provisioned projects in late 2024, so the first Firebase Functions deploy fails with *"missing permission on the build service account"*. This grant fixes it.

Closes [finance-doctor#56](https://github.com/lopeztech/finance-doctor/issues/56). Unblocks the deploy half of finance-doctor#52 and the functions half of finance-doctor#54.

## Test plan

- [ ] platform-infra apply workflow turns green
- [ ] Re-run finance-doctor \`Build & Deploy\` — \`Deploy Functions\` step completes
- [ ] \`gcloud functions list --regions=australia-southeast1 --project=finance-doctor-lcd\` shows all 7 functions
- [ ] E2E: log in to finance.lopezcloud.dev, trigger an advice call, confirm a response renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)