### PR TITLE
feat(finance-doctor): manage Firebase Auth authorized domains in Terraform

### DIFF
--- a/projects/finance-doctor/firebase.tf
+++ b/projects/finance-doctor/firebase.tf
@@ -112,3 +112,24 @@ resource "google_project_iam_member" "functions_runtime_secret_accessor" {
   role    = "roles/secretmanager.secretAccessor"
   member  = "serviceAccount:${google_service_account.functions_runtime.email}"
 }
+
+# ── Identity Platform / Firebase Auth config ──────────────────────────────────
+# Custom Hosting domains aren't auto-added to the Firebase Auth authorized-
+# domains list — without an entry here, sign-in at the domain fails with
+# auth/unauthorized-domain. Terraform takes full ownership of this list, so
+# every domain that must work for sign-in needs to be listed explicitly.
+#
+# The first three are Firebase defaults; finance.lopezcloud.dev is the custom
+# Hosting domain from #54.
+resource "google_identity_platform_config" "default" {
+  project = var.project_id
+
+  authorized_domains = [
+    "localhost",
+    "finance-doctor-lcd.firebaseapp.com",
+    "finance-doctor-lcd.web.app",
+    "finance.lopezcloud.dev",
+  ]
+
+  depends_on = [google_project_service.apis]
+}


### PR DESCRIPTION
## Summary

Custom Hosting domains aren't auto-added to Firebase Auth's authorized-domains list. Signing in at finance.lopezcloud.dev fails with \`auth/unauthorized-domain\` unless the domain is added via the Firebase Console — which is what you saw just now.

Adds a \`google_identity_platform_config\` resource with four domains:
- \`localhost\` — dev
- \`finance-doctor-lcd.firebaseapp.com\` — Firebase default
- \`finance-doctor-lcd.web.app\` — Firebase default
- \`finance.lopezcloud.dev\` — custom Hosting domain from #54

Closes [finance-doctor#57](https://github.com/lopeztech/finance-doctor/issues/57).

## Watch-out

Terraform now owns the full \`authorized_domains\` list. If any console-only entry exists on the live project (e.g. a preview-channel host) that isn't in this HCL, apply will delete it. Based on your symptom (unauthorized-domain for finance.lopezcloud.dev), the current live list is a subset of the defaults above — the apply should *add* finance.lopezcloud.dev and not remove anything.

## Test plan

- [ ] platform-infra apply turns green
- [ ] Sign in at https://finance.lopezcloud.dev succeeds
- [ ] Sign in at https://finance-doctor-lcd.web.app still succeeds (regression check)
- [ ] Drift check: remove finance.lopezcloud.dev from the console, re-apply, confirm Terraform restores it

🤖 Generated with [Claude Code](https://claude.com/claude-code)