### PR TITLE
feat(finance-doctor): grant allUsers invoker on Callable Function services

### DIFF
--- a/projects/finance-doctor/functions_public_access.tf
+++ b/projects/finance-doctor/functions_public_access.tf
@@ -1,0 +1,54 @@
+# ── Public-access plumbing for Firebase Callable Cloud Functions ──────────────
+# Firebase Callable Functions run as 2nd-gen Cloud Functions, which are
+# Cloud Run services under the hood. The browser's OPTIONS preflight for
+# every httpsCallable() invocation is unauthenticated at the transport
+# layer — the Firebase ID token is carried inside the POST body, not as a
+# Cloud Run IAM identity — so the underlying Cloud Run service needs an
+# allUsers → run.invoker binding for preflights to get through.
+#
+# ── One-time manual bootstrap (per project) ───────────────────────────────────
+# The organisation's iam.allowedPolicyMemberDomains constraint blocks
+# allUsers bindings by default. We override the constraint at the project
+# level. `roles/orgpolicy.policyAdmin` isn't grantable at the project
+# level, and granting it at the org level would be excessive scope for the
+# deployer SA — so the override itself is applied manually by a human
+# admin once, using their own org-admin credentials:
+#
+#   cat > /tmp/allow-public.yaml <<'EOF'
+#   name: projects/finance-doctor-lcd/policies/iam.allowedPolicyMemberDomains
+#   spec:
+#     rules:
+#     - allowAll: true
+#   EOF
+#   gcloud org-policies set-policy /tmp/allow-public.yaml
+#
+# Once the constraint is lifted, Terraform manages the invoker bindings
+# below. If the override is ever reverted at the org level, the next
+# apply will surface it via a failed IAM binding.
+
+locals {
+  callable_functions = [
+    "adviceChat",
+    "dashboardTips",
+    "taxAdvice",
+    "investmentsAdvice",
+    "expensesImport",
+    "expensesMigrate",
+    "expensesReanalyse",
+  ]
+}
+
+# Cloud Functions v2 names its underlying Cloud Run service identically to
+# the function name, so these resources bind directly to the generated
+# services without an explicit data lookup. The services are created by
+# `firebase deploy --only functions` from the finance-doctor app repo —
+# this file adds IAM bindings on top of them.
+resource "google_cloud_run_v2_service_iam_member" "public_callable_invoker" {
+  for_each = toset(local.callable_functions)
+
+  project  = var.project_id
+  location = var.region
+  name     = each.value
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}


### PR DESCRIPTION
## Summary

Callable Functions returned \`FirebaseError: internal\` from the browser because the OPTIONS preflight on each function's underlying Cloud Run service 403s without \`allUsers → run.invoker\`. The org-level \`iam.allowedPolicyMemberDomains\` constraint blocks allUsers by default — already overridden manually at the project level for finance-doctor-lcd. This PR codifies the invoker bindings for the seven Callable Functions and documents the one-time override step in a header comment so it's discoverable when someone adds the eighth function.

Fixes the CORS 403 that surfaced in the E2E for #56.

## Test plan

- [ ] platform-infra apply turns green
- [ ] Browser: sign in at finance.lopezcloud.dev, open Investments → "Get AI Advice" → advice renders (no \`internal\` error, no CORS 403)
- [ ] Dashboard loads tips without 403 (index creation for expenses query is a separate app-repo follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)