### PR TITLE
feat(finance-doctor): add project-wide and Vertex-AI budget alerts

### DIFF
--- a/projects/finance-doctor/monitoring.tf
+++ b/projects/finance-doctor/monitoring.tf
@@ -1,0 +1,78 @@
+# ── Budget Alerts ─────────────────────────────────────────────────────────────
+# Two budgets, one notification channel:
+#
+#   - Project-wide cap (var.monthly_budget_usd, via the shared budget module)
+#     — catches runaway spend on any service. Thresholds 50/80/100% current +
+#     100% forecasted.
+#
+#   - Vertex AI specific (var.vertex_ai_monthly_budget_aud, filtered on service
+#     ID C7E2-9256-1C43) — early warning for Gemini call volume blowing out.
+#     Gemini dominates the project's cost profile, so we want visibility
+#     well before the project-wide cap trips.
+#
+# Both alerts fire into the email channel provisioned inside the budget
+# module; the Vertex AI budget reuses that channel via module output so we
+# don't maintain two identical channels.
+
+module "budget" {
+  source = "../../modules/budget"
+
+  project_id         = var.project_id
+  env                = var.environment
+  billing_account    = var.billing_account
+  monthly_budget_usd = var.monthly_budget_usd
+  notification_email = var.notification_email
+
+  depends_on = [google_project_service.apis]
+}
+
+# Vertex AI service ID in the Cloud Billing catalog. Verified 2026-04-18 via
+# cloudbilling.googleapis.com/v1/services. If Google changes it, the budget
+# will silently stop filtering — revalidate periodically.
+locals {
+  vertex_ai_service_id = "services/C7E2-9256-1C43"
+}
+
+resource "google_billing_budget" "vertex_ai" {
+  billing_account = var.billing_account
+  display_name    = "${var.project_id}-${var.environment} Vertex AI Budget"
+
+  budget_filter {
+    projects = ["projects/${data.google_project.project.number}"]
+    services = [local.vertex_ai_service_id]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "AUD"
+      units         = tostring(var.vertex_ai_monthly_budget_aud)
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+    spend_basis       = "CURRENT_SPEND"
+  }
+
+  threshold_rules {
+    threshold_percent = 0.8
+    spend_basis       = "CURRENT_SPEND"
+  }
+
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "CURRENT_SPEND"
+  }
+
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = [module.budget.notification_channel_id]
+    disable_default_iam_recipients   = false
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/projects/finance-doctor/variables.tf
+++ b/projects/finance-doctor/variables.tf
@@ -59,3 +59,9 @@ variable "monthly_budget_usd" {
   type        = number
   default     = 20
 }
+
+variable "vertex_ai_monthly_budget_aud" {
+  description = "Monthly budget for Vertex AI (Gemini) spend specifically, in the billing account's native currency (AUD). Separate from the project-wide cap so Gemini blow-outs get their own early-warning alert."
+  type        = number
+  default     = 10
+}


### PR DESCRIPTION
## Summary

Two budgets, one email channel:

- **Project-wide cap** (existing \`var.monthly_budget_usd = 20\`, wired through the shared \`modules/budget\`) — catches runaway spend on any service.
- **Vertex AI specific** (new \`var.vertex_ai_monthly_budget_aud = 10\`, filtered on Cloud Billing service ID \`C7E2-9256-1C43\`) — early warning for Gemini call volume blowing out *before* the project-wide cap trips.

Both alerts fire into the email channel provisioned by the module; the Vertex AI budget reuses it via module output so we don't maintain two identical channels.

Service ID verified today against \`cloudbilling.googleapis.com/v1/services\`.

Closes [finance-doctor#40](https://github.com/lopeztech/finance-doctor/issues/40).

## Test plan

- [ ] platform-infra apply turns green
- [ ] Two budgets visible in GCP Billing → Budgets & alerts for finance-doctor-lcd
- [ ] Email notification channel resolves to admin@lopezcloud.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)