### PR TITLE
feat(finance-doctor): Pub/Sub topic for bulk expense-categorise fan-out

### DIFF
--- a/projects/finance-doctor/pubsub.tf
+++ b/projects/finance-doctor/pubsub.tf
@@ -1,0 +1,34 @@
+# ── Pub/Sub — Bulk Expense Categorisation Fan-out ────────────────────────────
+# Backs the `expensesCategoriseWorker` Firebase Function. On bulk CSV imports
+# (>50 rows), `expensesImport` saves rows with categorisationStatus=pending and
+# publishes one message per row to this topic; the worker then calls Gemini
+# per-row and patches Firestore. Small imports keep the synchronous AI-at-
+# preview flow and do not touch this topic.
+
+resource "google_pubsub_topic" "expense_categorise" {
+  name    = "expense-categorise"
+  project = var.project_id
+
+  message_retention_duration = "604800s" # 7 days
+
+  labels = local.labels
+
+  depends_on = [google_project_service.apis]
+}
+
+# Functions runtime SA publishes per-expense messages during bulk imports.
+resource "google_pubsub_topic_iam_member" "functions_runtime_publisher" {
+  project = var.project_id
+  topic   = google_pubsub_topic.expense_categorise.name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.functions_runtime.email}"
+}
+
+# Firebase Functions v2 Pub/Sub triggers deliver via Eventarc. The runtime SA
+# needs eventarc.eventReceiver at the project level for Eventarc to invoke the
+# worker's underlying Cloud Run service.
+resource "google_project_iam_member" "functions_runtime_eventarc_receiver" {
+  project = var.project_id
+  role    = "roles/eventarc.eventReceiver"
+  member  = "serviceAccount:${google_service_account.functions_runtime.email}"
+}


### PR DESCRIPTION
## Summary
- Adds Pub/Sub topic `expense-categorise` (7-day retention) in the finance-doctor project
- Grants `finance-doctor-functions` SA `roles/pubsub.publisher` on the topic so `expensesImport` can publish per-row messages
- Grants `roles/eventarc.eventReceiver` at project level so Eventarc can invoke the new Firebase Functions v2 Pub/Sub-triggered worker

## Why
On bulk CSV uploads (>50 rows), the synchronous Gemini categorisation inside `expensesImport` preview blocks the client for long periods and risks hitting function timeouts. This fan-out lets `expensesImport` save rows with `categorisationStatus=pending` and publish one message per row to this topic; the new `expensesCategoriseWorker` function categorises each row and patches Firestore. Small imports (≤50 rows) keep the existing AI-at-preview UX — the topic is only used for bulk.

## Companion
App-side changes (the worker function + publishing + UI progress) ship in the finance-doctor repo separately. This Terraform lands first so the topic exists by the time the worker deploys.

## Test plan
- [ ] `terraform plan` cleanly adds 3 resources
- [ ] After merge + apply, the worker's `firebase deploy --only functions` succeeds (Eventarc trigger attaches)
- [ ] Verify the topic appears in Pub/Sub console and the IAM bindings are in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)