### PR TITLE
feat(fantasy-coach): scaffold Cloud Run + IAM + WIF

### DIFF
--- a/.github/workflows/fantasy-coach-apply.yml
+++ b/.github/workflows/fantasy-coach-apply.yml
@@ -1,0 +1,106 @@
+name: fantasy-coach — Apply
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'projects/fantasy-coach/**'
+      - 'modules/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    env:
+      TF_DIR: projects/fantasy-coach
+      TF_ENV: prod
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~1.6"
+
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.FANTASY_COACH_WIF_PROVIDER }}
+          service_account: ${{ secrets.FANTASY_COACH_SA_EMAIL }}
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=${{ env.TF_DIR }} init \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -backend-config="prefix=terraform/state/fantasy-coach/${{ env.TF_ENV }}" \
+            -input=false
+
+      - name: Terraform Apply
+        run: |
+          terraform -chdir=${{ env.TF_DIR }} apply \
+            -var-file="environments/${{ env.TF_ENV }}/terraform.tfvars" \
+            -var="billing_account=${{ secrets.BILLING_ACCOUNT_ID }}" \
+            -input=false \
+            -auto-approve
+
+  verify:
+    needs: apply
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: fantasy-coach-lcd
+      REGION: australia-southeast1
+    steps:
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.FANTASY_COACH_WIF_PROVIDER }}
+          service_account: ${{ secrets.FANTASY_COACH_SA_EMAIL }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Verify infrastructure
+        run: |
+          set -euo pipefail
+          PASS=0; FAIL=0; ERRORS=()
+
+          check() {
+            local label="$1"; shift
+            if "$@" &>/dev/null; then
+              echo "  ✅ $label"; ((PASS++)) || true
+            else
+              echo "  ❌ $label"; ((FAIL++)) || true; ERRORS+=("$label")
+            fi
+          }
+
+          echo "── APIs ──"
+          for api in iam.googleapis.com run.googleapis.com artifactregistry.googleapis.com; do
+            check "API: $api" \
+              gcloud services list --project="$PROJECT_ID" --filter="config.name=$api" --format="value(state)"
+          done
+
+          echo "── Service Accounts ──"
+          check "SA: fantasy-coach-runtime" \
+            gcloud iam service-accounts describe "fantasy-coach-runtime@${PROJECT_ID}.iam.gserviceaccount.com" --project="$PROJECT_ID"
+          check "SA: fantasy-coach-deployer" \
+            gcloud iam service-accounts describe "fantasy-coach-deployer@${PROJECT_ID}.iam.gserviceaccount.com" --project="$PROJECT_ID"
+
+          echo "── Artifact Registry ──"
+          check "AR repo: fantasy-coach" \
+            gcloud artifacts repositories describe fantasy-coach --project="$PROJECT_ID" --location="$REGION"
+
+          echo "── Cloud Run ──"
+          check "Service: fantasy-coach-api" \
+            gcloud run services describe fantasy-coach-api --project="$PROJECT_ID" --region="$REGION"
+
+          echo ""
+          echo "════════════════════════════════════════"
+          echo "  Passed: $PASS  Failed: $FAIL"
+          if [[ ${#ERRORS[@]} -gt 0 ]]; then
+            echo "  Failures:"
+            for e in "${ERRORS[@]}"; do echo "    - $e"; done
+          fi
+          echo "════════════════════════════════════════"
+          [[ $FAIL -eq 0 ]]

--- a/.github/workflows/fantasy-coach-plan.yml
+++ b/.github/workflows/fantasy-coach-plan.yml
@@ -1,0 +1,63 @@
+name: fantasy-coach — Plan
+
+on:
+  pull_request:
+    paths:
+      - 'projects/fantasy-coach/**'
+      - 'modules/**'
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    env:
+      TF_DIR: projects/fantasy-coach
+      TF_ENV: prod
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~1.6"
+
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.FANTASY_COACH_WIF_PROVIDER }}
+          service_account: ${{ secrets.FANTASY_COACH_SA_EMAIL }}
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=${{ env.TF_DIR }} init \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -backend-config="prefix=terraform/state/fantasy-coach/${{ env.TF_ENV }}" \
+            -input=false
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform -chdir=${{ env.TF_DIR }} plan \
+            -var-file="environments/${{ env.TF_ENV }}/terraform.tfvars" \
+            -var="billing_account=${{ secrets.BILLING_ACCOUNT_ID }}" \
+            -input=false \
+            -no-color \
+            -out=tfplan 2>&1 | tee plan.txt
+          echo "exitcode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v8
+        if: always()
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('plan.txt', 'utf8');
+            const truncated = plan.length > 60000 ? plan.slice(-60000) + '\n\n...(truncated)' : plan;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Terraform Plan — \`fantasy-coach/prod\`\n\`\`\`\n${truncated}\n\`\`\``
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ versions.tf         # Root provider requirements (google ~> 5.0, terraform >= 1.
 |---------|-------------|----------------|--------|
 | home-plant-tracker | prod | home-plant-tracker-lcd | plants.lopezcloud.dev |
 | data-feeder | single | data-feeder-lcd | datafeeder.lopezcloud.dev |
+| finance-doctor | prod | finance-doctor-lcd | finance.lopezcloud.dev |
+| fantasy-coach | prod | fantasy-coach-lcd | (TBD — see lopeztech/fantasy-coach#19) |
 
 ## Terraform workflow
 
@@ -60,6 +62,8 @@ terraform apply -var-file="environments/<env>/terraform.tfvars"
 | `GEMINI_API_KEY` | home-plant-tracker |
 | `DATA_FEEDER_WIF_PROVIDER` | data-feeder |
 | `DATA_FEEDER_SA_EMAIL` | data-feeder |
+| `FANTASY_COACH_WIF_PROVIDER` | fantasy-coach |
+| `FANTASY_COACH_SA_EMAIL` | fantasy-coach |
 
 ## Naming conventions
 

--- a/projects/fantasy-coach/cloudrun.tf
+++ b/projects/fantasy-coach/cloudrun.tf
@@ -1,0 +1,99 @@
+# ── Artifact Registry ────────────────────────────────────────────────────────
+
+resource "google_artifact_registry_repository" "app" {
+  location      = var.region
+  repository_id = local.app_name
+  description   = "Fantasy Coach API Docker images"
+  format        = "DOCKER"
+  project       = var.project_id
+
+  labels     = local.labels
+  depends_on = [google_project_service.apis]
+}
+
+# Deployer already has project-wide roles/artifactregistry.writer via iam.tf,
+# so no per-repo grant is needed. (Explicit repo-level grant left out to
+# avoid double-binding.)
+
+# ── Cloud Run ────────────────────────────────────────────────────────────────
+# Scale-to-zero, CPU throttled (idle cost ≈ $0). Image is managed by the
+# lopeztech/fantasy-coach deploy workflow; terraform creates the service
+# with a placeholder image and then ignores it on future plans.
+
+resource "google_cloud_run_v2_service" "api" {
+  name     = "${local.app_name}-api"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_ALL"
+  project  = var.project_id
+
+  template {
+    service_account = google_service_account.runtime.email
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 2
+    }
+
+    containers {
+      # Placeholder. First real image is pushed + deployed by the app-repo
+      # workflow in lopeztech/fantasy-coach; terraform ignores image drift
+      # (see lifecycle block below).
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+        cpu_idle          = true # throttle CPU when not serving a request
+        startup_cpu_boost = true # briefly lift the throttle on cold start
+      }
+
+      startup_probe {
+        http_get { path = "/healthz" }
+        initial_delay_seconds = 0
+        period_seconds        = 5
+        failure_threshold     = 5
+        timeout_seconds       = 3
+      }
+
+      liveness_probe {
+        http_get { path = "/healthz" }
+        initial_delay_seconds = 10
+        period_seconds        = 30
+      }
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  labels = local.labels
+
+  lifecycle {
+    ignore_changes = [
+      # The app-repo deploy workflow rotates the image. Terraform shouldn't
+      # churn it back to the placeholder on the next plan.
+      template[0].containers[0].image,
+      # `client` / `client_version` are set by `gcloud run deploy` and would
+      # otherwise show as cosmetic drift on every apply.
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_project_iam_member.deployer,
+  ]
+}
+
+# No allUsers invoker — auth wiring lives in #17. For now the service is
+# reachable only via identity tokens (Google-signed), which is what the
+# deploy workflow uses for its /healthz smoke test.

--- a/projects/fantasy-coach/environments/prod/terraform.tfvars
+++ b/projects/fantasy-coach/environments/prod/terraform.tfvars
@@ -1,0 +1,9 @@
+project_id               = "fantasy-coach-lcd"
+region                   = "australia-southeast1"
+environment              = "prod"
+github_org               = "lopeztech"
+github_repo              = "platform-infra"
+app_github_repo          = "fantasy-coach"
+terraform_operator_email = "admin@lopezcloud.dev"
+notification_email       = "admin@lopezcloud.dev"
+monthly_budget_usd       = 20

--- a/projects/fantasy-coach/iam.tf
+++ b/projects/fantasy-coach/iam.tf
@@ -94,7 +94,7 @@ resource "google_service_account_iam_member" "deployer_act_as_runtime" {
 
 resource "google_iam_workload_identity_pool" "github" {
   workload_identity_pool_id = "${local.app_name}-github-pool"
-  display_name              = "GitHub Actions Pool (platform-infra)"
+  display_name              = "GHA Pool (platform-infra)"
   description               = "Identity pool for platform-infra OIDC tokens"
   project                   = var.project_id
 
@@ -131,7 +131,7 @@ resource "google_service_account_iam_member" "github_wif_binding" {
 
 resource "google_iam_workload_identity_pool" "github_app" {
   workload_identity_pool_id = "${local.app_name}-app-github-pool"
-  display_name              = "GitHub Actions Pool (app repo)"
+  display_name              = "GHA Pool (app repo)"
   description               = "Identity pool for lopeztech/fantasy-coach OIDC tokens"
   project                   = var.project_id
 

--- a/projects/fantasy-coach/iam.tf
+++ b/projects/fantasy-coach/iam.tf
@@ -1,0 +1,166 @@
+# ── Terraform Operator IAM Roles ─────────────────────────────────────────────
+# Grants the account that runs `terraform apply` the minimum roles it needs
+# for this configuration. Bootstrap the first apply as a project Owner; after
+# that, these bindings plus the deployer SA below are sufficient.
+
+locals {
+  operator_member = length(regexall("^serviceAccount:", var.terraform_operator_email)) > 0 ? var.terraform_operator_email : "user:${var.terraform_operator_email}"
+
+  operator_roles = [
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/storage.admin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/run.admin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/artifactregistry.admin",
+  ]
+}
+
+resource "google_project_iam_member" "terraform_operator" {
+  for_each = toset(local.operator_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = local.operator_member
+}
+
+# ── Runtime SA — used by the Cloud Run revision at request time ──────────────
+# Least privilege on purpose. Firestore / Secret Manager / Vertex roles are
+# added in the issues that introduce those dependencies (#15, #16, #22).
+
+resource "google_service_account" "runtime" {
+  account_id   = "${local.app_name}-runtime"
+  display_name = "Fantasy Coach Cloud Run runtime"
+  description  = "Identity the Cloud Run revision runs as"
+  project      = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+# No project-level roles yet — runtime currently only needs to serve /healthz.
+# Future issues add:
+#   - roles/datastore.user            (#15 Firestore)
+#   - roles/secretmanager.secretAccessor (#16 Secret Manager)
+#   - roles/aiplatform.user           (#22 Vertex Gemini)
+
+# ── Deployer SA — used by GitHub Actions to roll revisions ───────────────────
+
+resource "google_service_account" "github_deployer" {
+  account_id   = "${local.app_name}-deployer"
+  display_name = "Fantasy Coach GitHub Actions Deployer"
+  description  = "Builds images and rolls Cloud Run revisions from CI"
+  project      = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+locals {
+  deployer_roles = [
+    "roles/run.admin",
+    "roles/artifactregistry.writer",
+    "roles/iam.serviceAccountUser",        # to let Cloud Run run as runtime SA
+    "roles/iam.serviceAccountAdmin",       # terraform manages this SA
+    "roles/iam.workloadIdentityPoolAdmin", # terraform manages the WIF pool
+    "roles/storage.admin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/logging.admin",
+    "roles/monitoring.admin",
+  ]
+}
+
+resource "google_project_iam_member" "deployer" {
+  for_each = toset(local.deployer_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+# Deployer must be able to deploy a Cloud Run revision whose identity is the
+# runtime SA. That's a per-SA binding (iam.serviceAccountUser), not project-
+# wide, so scope it explicitly.
+resource "google_service_account_iam_member" "deployer_act_as_runtime" {
+  service_account_id = google_service_account.runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+# ── Workload Identity Federation ─────────────────────────────────────────────
+# Two pools: one for terraform runs from platform-infra, one for app-repo
+# deploys from lopeztech/fantasy-coach. Kept separate so a compromised app
+# repo can't push terraform changes, and vice versa.
+
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = "${local.app_name}-github-pool"
+  display_name              = "GitHub Actions Pool (platform-infra)"
+  description               = "Identity pool for platform-infra OIDC tokens"
+  project                   = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider"
+  display_name                       = "GitHub OIDC Provider"
+  project                            = var.project_id
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  attribute_condition = "assertion.repository == '${var.github_org}/${var.github_repo}' && assertion.ref == 'refs/heads/master'"
+}
+
+resource "google_service_account_iam_member" "github_wif_binding" {
+  service_account_id = google_service_account.github_deployer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_org}/${var.github_repo}"
+}
+
+# App-repo pool — lets lopeztech/fantasy-coach CI build + deploy images.
+
+resource "google_iam_workload_identity_pool" "github_app" {
+  workload_identity_pool_id = "${local.app_name}-app-github-pool"
+  display_name              = "GitHub Actions Pool (app repo)"
+  description               = "Identity pool for lopeztech/fantasy-coach OIDC tokens"
+  project                   = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github_app" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_app.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-app-provider"
+  display_name                       = "GitHub OIDC Provider (app repo)"
+  project                            = var.project_id
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  # App-repo deploys run from main, not master.
+  attribute_condition = "assertion.repository == '${var.github_org}/${var.app_github_repo}' && assertion.ref == 'refs/heads/main'"
+}
+
+resource "google_service_account_iam_member" "github_app_wif_binding" {
+  service_account_id = google_service_account.github_deployer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_app.name}/attribute.repository/${var.github_org}/${var.app_github_repo}"
+}

--- a/projects/fantasy-coach/main.tf
+++ b/projects/fantasy-coach/main.tf
@@ -1,0 +1,42 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  app_name = "fantasy-coach"
+  labels = {
+    app         = local.app_name
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+
+# ── APIs ─────────────────────────────────────────────────────────────────────
+# Minimum set for #14 (Cloud Run + Artifact Registry + IAM/WIF). Firestore,
+# Secret Manager, Firebase, and Vertex APIs are added in their own issues
+# (#15, #16, #17, #19, #22) so each gets reviewed independently.
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "billingbudgets.googleapis.com",
+    "serviceusage.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+  ])
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}

--- a/projects/fantasy-coach/outputs.tf
+++ b/projects/fantasy-coach/outputs.tf
@@ -1,0 +1,37 @@
+output "project_id" {
+  value       = var.project_id
+  description = "GCP project hosting fantasy-coach"
+}
+
+output "region" {
+  value = var.region
+}
+
+output "runtime_sa_email" {
+  value       = google_service_account.runtime.email
+  description = "Cloud Run runtime service account email"
+}
+
+output "deployer_sa_email" {
+  value       = google_service_account.github_deployer.email
+  description = "GitHub Actions deployer service account email (→ FANTASY_COACH_DEPLOYER_SA secret in both repos)"
+}
+
+output "wif_provider_name" {
+  value       = google_iam_workload_identity_pool_provider.github.name
+  description = "Platform-infra WIF provider full resource name (→ FANTASY_COACH_WIF_PROVIDER secret in platform-infra)"
+}
+
+output "app_wif_provider_name" {
+  value       = google_iam_workload_identity_pool_provider.github_app.name
+  description = "App-repo WIF provider full resource name (→ FANTASY_COACH_WIF_PROVIDER secret in lopeztech/fantasy-coach)"
+}
+
+output "cloud_run_service_name" {
+  value = google_cloud_run_v2_service.api.name
+}
+
+output "artifact_registry_repo" {
+  value       = google_artifact_registry_repository.app.repository_id
+  description = "Repository ID for pushing images (full path: {region}-docker.pkg.dev/{project}/{repo})"
+}

--- a/projects/fantasy-coach/variables.tf
+++ b/projects/fantasy-coach/variables.tf
@@ -1,0 +1,56 @@
+variable "project_id" {
+  description = "Google Cloud project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "Google Cloud region for regional resources"
+  type        = string
+  default     = "australia-southeast1"
+}
+
+variable "environment" {
+  description = "Deployment environment label (prod, staging, etc.)"
+  type        = string
+  default     = "prod"
+}
+
+variable "github_org" {
+  description = "GitHub organisation or username that owns the repositories"
+  type        = string
+  default     = "lopeztech"
+}
+
+variable "github_repo" {
+  description = "GitHub repository name that triggers terraform (the infra repo)"
+  type        = string
+  default     = "platform-infra"
+}
+
+variable "app_github_repo" {
+  description = "GitHub repository name for the fantasy-coach application code"
+  type        = string
+  default     = "fantasy-coach"
+}
+
+variable "terraform_operator_email" {
+  description = "Email (user:) or SA (serviceAccount:) that runs terraform apply"
+  type        = string
+}
+
+variable "notification_email" {
+  description = "Email address for monitoring alert notifications"
+  type        = string
+  default     = "admin@lopezcloud.dev"
+}
+
+variable "billing_account" {
+  description = "GCP billing account ID (format: XXXXXX-XXXXXX-XXXXXX)"
+  type        = string
+}
+
+variable "monthly_budget_usd" {
+  description = "Monthly budget in USD"
+  type        = number
+  default     = 20
+}

--- a/projects/fantasy-coach/versions.tf
+++ b/projects/fantasy-coach/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {
+    # Populated at init time:
+    #   terraform init \
+    #     -backend-config="bucket=platform-infra-lcd-tf-state" \
+    #     -backend-config="prefix=terraform/state/fantasy-coach/prod"
+  }
+}


### PR DESCRIPTION
Infra side of [lopeztech/fantasy-coach#14](https://github.com/lopeztech/fantasy-coach/issues/14). Pairs with the app-side PR [lopeztech/fantasy-coach#46](https://github.com/lopeztech/fantasy-coach/pull/46) (deploy docs + GHA workflow).

Scope is intentionally minimal — just what's needed to land a healthy `/healthz` on Cloud Run. Firestore, Secret Manager, Firebase, and Vertex pieces are deferred to their own backlog issues so each lands as a reviewable diff rather than as one monolithic 1k-line scaffold.

## What's in `projects/fantasy-coach/`
- `main.tf` — Google provider, minimum API set (`run`, `artifactregistry`, `iam`, `sts`, `cloudbuild`, `billing`, `monitoring`, `logging`).
- `iam.tf` — terraform operator roles, runtime SA (no project roles yet — added per future issue), deployer SA, **two** WIF pools (one for `lopeztech/platform-infra`, one for `lopeztech/fantasy-coach`'s app repo). Separate pools so a compromised app repo can't push terraform changes and vice versa.
- `cloudrun.tf` — Artifact Registry repo + Cloud Run v2 service. `min_instance_count=0`, `cpu_idle=true` (idle cost ≈ \$0). Image is rotated by the app-repo deploy workflow; terraform ignores image drift via `lifecycle.ignore_changes`.
- `outputs.tf` — `wif_provider_name`, `app_wif_provider_name`, `deployer_sa_email`, `project_id`, etc.
- `environments/prod/terraform.tfvars` — \`project_id = \"fantasy-coach-lcd\"\`, \`region = \"australia-southeast1\"\`.

## CI
\`fantasy-coach-{plan,apply}.yml\` follow the finance-doctor pattern. The \`verify\` step covers four core invariants (APIs enabled, both SAs exist, AR repo exists, Cloud Run service exists).

\`CLAUDE.md\` project + secrets tables updated.

## Bootstrap required before this can apply
1. Create \`fantasy-coach-lcd\` GCP project linked to billing (Owner access; one-off).
2. First \`terraform apply\` runs locally as the operator email — the WIF pool this terraform creates *is* the credential subsequent CI runs use.
3. After first apply, copy the four output values into the GitHub secrets:
   - In **platform-infra**: \`FANTASY_COACH_WIF_PROVIDER\` ← \`wif_provider_name\`, \`FANTASY_COACH_SA_EMAIL\` ← \`deployer_sa_email\`
   - In **lopeztech/fantasy-coach**: \`FANTASY_COACH_WIF_PROVIDER\` ← \`app_wif_provider_name\`, \`FANTASY_COACH_DEPLOYER_SA\` ← \`deployer_sa_email\`, \`FANTASY_COACH_PROJECT_ID\` ← \`project_id\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)