### PR TITLE
feat(fantasy-coach): Firebase Hosting + fantasy.lopezcloud.dev (lopeztech/fantasy-coach#19)

### DIFF
--- a/.github/workflows/fantasy-coach-apply.yml
+++ b/.github/workflows/fantasy-coach-apply.yml
@@ -39,6 +39,8 @@ jobs:
             -input=false
 
       - name: Terraform Apply
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           terraform -chdir=${{ env.TF_DIR }} apply \
             -var-file="environments/${{ env.TF_ENV }}/terraform.tfvars" \
@@ -76,7 +78,14 @@ jobs:
           }
 
           echo "── APIs ──"
-          for api in iam.googleapis.com run.googleapis.com artifactregistry.googleapis.com; do
+          for api in \
+              iam.googleapis.com \
+              run.googleapis.com \
+              artifactregistry.googleapis.com \
+              firebase.googleapis.com \
+              firebasehosting.googleapis.com \
+              identitytoolkit.googleapis.com \
+              secretmanager.googleapis.com; do
             check "API: $api" \
               gcloud services list --project="$PROJECT_ID" --filter="config.name=$api" --format="value(state)"
           done
@@ -94,6 +103,16 @@ jobs:
           echo "── Cloud Run ──"
           check "Service: fantasy-coach-api" \
             gcloud run services describe fantasy-coach-api --project="$PROJECT_ID" --region="$REGION"
+
+          echo "── Firebase Hosting ──"
+          check "Hosting site: fantasy-coach-lcd" \
+            gcloud firebase hosting sites describe fantasy-coach-lcd --project="$PROJECT_ID"
+
+          echo "── Secret Manager (Firebase Web config) ──"
+          for s in firebase-web-api-key firebase-web-auth-domain firebase-web-project-id firebase-web-app-id; do
+            check "Secret: $s" \
+              gcloud secrets describe "$s" --project="$PROJECT_ID"
+          done
 
           echo ""
           echo "════════════════════════════════════════"

--- a/.github/workflows/fantasy-coach-plan.yml
+++ b/.github/workflows/fantasy-coach-plan.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Terraform Plan
         id: plan
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           terraform -chdir=${{ env.TF_DIR }} plan \
             -var-file="environments/${{ env.TF_ENV }}/terraform.tfvars" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ versions.tf         # Root provider requirements (google ~> 5.0, terraform >= 1.
 | home-plant-tracker | prod | home-plant-tracker-lcd | plants.lopezcloud.dev |
 | data-feeder | single | data-feeder-lcd | datafeeder.lopezcloud.dev |
 | finance-doctor | prod | finance-doctor-lcd | finance.lopezcloud.dev |
-| fantasy-coach | prod | fantasy-coach-lcd | (TBD — see lopeztech/fantasy-coach#19) |
+| fantasy-coach | prod | fantasy-coach-lcd | fantasy.lopezcloud.dev |
 
 ## Terraform workflow
 

--- a/projects/fantasy-coach/dns.tf
+++ b/projects/fantasy-coach/dns.tf
@@ -1,0 +1,21 @@
+# Cloudflare DNS zone for lopezcloud.dev — shared across every project on
+# this domain. The provider reads CLOUDFLARE_API_TOKEN from the environment;
+# no credentials are stored in state or config.
+provider "cloudflare" {}
+
+data "cloudflare_zone" "lopezcloud" {
+  name = "lopezcloud.dev"
+}
+
+# Firebase Hosting custom domain — DNS-only (grey cloud) so Firebase provides
+# its own CDN and SSL termination. Proxying through Cloudflare would break
+# Firebase's managed-certificate issuance (which uses ACME against the CNAME
+# target).
+resource "cloudflare_record" "fantasy" {
+  zone_id = data.cloudflare_zone.lopezcloud.id
+  name    = "fantasy"
+  type    = "CNAME"
+  content = "${google_firebase_hosting_site.app.site_id}.web.app"
+  proxied = false
+  ttl     = 3600
+}

--- a/projects/fantasy-coach/environments/prod/terraform.tfvars
+++ b/projects/fantasy-coach/environments/prod/terraform.tfvars
@@ -1,5 +1,6 @@
 project_id               = "fantasy-coach-lcd"
 region                   = "australia-southeast1"
+domain                   = "fantasy.lopezcloud.dev"
 environment              = "prod"
 github_org               = "lopeztech"
 github_repo              = "platform-infra"

--- a/projects/fantasy-coach/firebase.tf
+++ b/projects/fantasy-coach/firebase.tf
@@ -1,0 +1,81 @@
+# ── Firebase Project ─────────────────────────────────────────────────────────
+# Initialises Firebase on the GCP project. Required before any Firebase
+# resources (Hosting, Auth, Web App) can be created.
+
+resource "google_firebase_project" "default" {
+  provider = google-beta
+  project  = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+# ── Firebase Hosting ─────────────────────────────────────────────────────────
+# Serves the Vite + React SPA from lopeztech/fantasy-coach (web/). Custom
+# domain points at fantasy.lopezcloud.dev; the default *.web.app URL stays
+# available for rollback and smoke-testing.
+
+resource "google_firebase_hosting_site" "app" {
+  provider = google-beta
+  project  = var.project_id
+  site_id  = var.project_id # fantasy-coach-lcd → fantasy-coach-lcd.web.app
+
+  depends_on = [google_firebase_project.default]
+}
+
+resource "google_firebase_hosting_custom_domain" "app" {
+  provider      = google-beta
+  project       = var.project_id
+  site_id       = google_firebase_hosting_site.app.site_id
+  custom_domain = var.domain # fantasy.lopezcloud.dev
+
+  # We skip Terraform's DNS-verification wait because the Cloudflare CNAME is
+  # created in parallel in dns.tf. Firebase will verify the domain as soon as
+  # DNS propagates (usually <5 min) and then issue the managed certificate.
+  wait_dns_verification = false
+}
+
+# ── Firebase Web App ─────────────────────────────────────────────────────────
+# Registers a Firebase Web App so the browser SDK can initialise. The config
+# (api_key, auth_domain, app_id) is fetched via the data source and published
+# to Secret Manager in firebase_secrets.tf so the app-repo deploy workflow
+# can build the SPA with live values.
+
+resource "google_firebase_web_app" "app" {
+  provider        = google-beta
+  project         = var.project_id
+  display_name    = "Fantasy Coach"
+  deletion_policy = "DELETE"
+
+  depends_on = [google_firebase_project.default]
+}
+
+data "google_firebase_web_app_config" "app" {
+  provider   = google-beta
+  project    = var.project_id
+  web_app_id = google_firebase_web_app.app.app_id
+}
+
+# ── Firebase Auth / Identity Platform ────────────────────────────────────────
+# Custom Hosting domains aren't auto-added to Firebase Auth's authorized-
+# domains list — without an entry here, sign-in from fantasy.lopezcloud.dev
+# fails with auth/unauthorized-domain. Terraform takes full ownership of the
+# list, so every origin that must work for sign-in needs to be listed.
+#
+# Entries:
+#   - localhost: dev server + Vite preview
+#   - *.firebaseapp.com / *.web.app: Firebase Hosting defaults (also used by
+#     signInWithPopup's redirect flow under the hood)
+#   - fantasy.lopezcloud.dev: the production custom domain (this PR)
+
+resource "google_identity_platform_config" "default" {
+  project = var.project_id
+
+  authorized_domains = [
+    "localhost",
+    "${var.project_id}.firebaseapp.com",
+    "${var.project_id}.web.app",
+    var.domain,
+  ]
+
+  depends_on = [google_project_service.apis]
+}

--- a/projects/fantasy-coach/firebase_secrets.tf
+++ b/projects/fantasy-coach/firebase_secrets.tf
@@ -1,0 +1,46 @@
+# Publishes the Firebase Web App config to Secret Manager so the app-repo
+# SPA deploy workflow can fetch VITE_FIREBASE_* values at build time without
+# hard-coding them in workflow YAML. api_key and auth_domain are semi-
+# sensitive; project_id and app_id are public, but keeping all four in Secret
+# Manager gives the deploy workflow one consistent fetch path.
+
+locals {
+  firebase_web_secrets = {
+    "firebase-web-api-key"     = data.google_firebase_web_app_config.app.api_key
+    "firebase-web-auth-domain" = data.google_firebase_web_app_config.app.auth_domain
+    "firebase-web-project-id"  = var.project_id
+    "firebase-web-app-id"      = google_firebase_web_app.app.app_id
+  }
+}
+
+resource "google_secret_manager_secret" "firebase_web" {
+  for_each = local.firebase_web_secrets
+
+  project   = var.project_id
+  secret_id = each.key
+  labels    = local.labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "firebase_web" {
+  for_each = local.firebase_web_secrets
+
+  secret      = google_secret_manager_secret.firebase_web[each.key].id
+  secret_data = each.value
+}
+
+# Deployer SA needs to read these secrets at SPA build time (see the
+# forthcoming web-deploy.yml workflow in lopeztech/fantasy-coach#72).
+resource "google_secret_manager_secret_iam_member" "firebase_web_deployer" {
+  for_each = local.firebase_web_secrets
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.firebase_web[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.github_deployer.email}"
+}

--- a/projects/fantasy-coach/iam.tf
+++ b/projects/fantasy-coach/iam.tf
@@ -67,6 +67,8 @@ locals {
     "roles/resourcemanager.projectIamAdmin",
     "roles/logging.admin",
     "roles/monitoring.admin",
+    # Firebase Hosting deploys from lopeztech/fantasy-coach#72.
+    "roles/firebasehosting.admin",
   ]
 }
 

--- a/projects/fantasy-coach/main.tf
+++ b/projects/fantasy-coach/main.tf
@@ -13,9 +13,12 @@ locals {
 }
 
 # ── APIs ─────────────────────────────────────────────────────────────────────
-# Minimum set for #14 (Cloud Run + Artifact Registry + IAM/WIF). Firestore,
-# Secret Manager, Firebase, and Vertex APIs are added in their own issues
-# (#15, #16, #17, #19, #22) so each gets reviewed independently.
+# Incrementally extended per issue so each scope lands in its own review:
+#   #14 (Cloud Run + Artifact Registry + IAM/WIF) — originally added here.
+#   #19 (SPA + Firebase Hosting + custom domain) — adds firebase/hosting/
+#       identitytoolkit/secretmanager. Covers Firebase Auth Google sign-in
+#       from fantasy.lopezcloud.dev and publishing the Web App config.
+# Firestore (#15) and Vertex AI (#22) are still pending their own PRs.
 
 resource "google_project_service" "apis" {
   for_each = toset([
@@ -30,6 +33,11 @@ resource "google_project_service" "apis" {
     "serviceusage.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",
+    # Added in #19 (SPA hosting + auth).
+    "firebase.googleapis.com",
+    "firebasehosting.googleapis.com",
+    "identitytoolkit.googleapis.com",
+    "secretmanager.googleapis.com",
   ])
 
   project            = var.project_id

--- a/projects/fantasy-coach/main.tf
+++ b/projects/fantasy-coach/main.tf
@@ -22,6 +22,11 @@ locals {
 
 resource "google_project_service" "apis" {
   for_each = toset([
+    # Needed by the google provider itself for project IAM reads. Without
+    # this, every terraform plan in CI fails with "Cloud Resource Manager
+    # API has not been used in project N" — the deployer SA's quota project
+    # is fantasy-coach-lcd, and the API has to be enabled there.
+    "cloudresourcemanager.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "sts.googleapis.com",

--- a/projects/fantasy-coach/outputs.tf
+++ b/projects/fantasy-coach/outputs.tf
@@ -35,3 +35,30 @@ output "artifact_registry_repo" {
   value       = google_artifact_registry_repository.app.repository_id
   description = "Repository ID for pushing images (full path: {region}-docker.pkg.dev/{project}/{repo})"
 }
+
+# ── Firebase Hosting / Web App outputs ──────────────────────────────────────
+
+output "firebase_hosting_site_id" {
+  description = "Firebase Hosting site id — target for `firebase deploy --only hosting`"
+  value       = google_firebase_hosting_site.app.site_id
+}
+
+output "firebase_hosting_default_url" {
+  description = "Default *.web.app URL for the Hosting site (rollback target)"
+  value       = "https://${google_firebase_hosting_site.app.site_id}.web.app"
+}
+
+output "firebase_hosting_custom_domain" {
+  description = "Public custom domain the SPA is served from"
+  value       = google_firebase_hosting_custom_domain.app.custom_domain
+}
+
+output "firebase_web_app_id" {
+  description = "Firebase Web App ID — used by the SPA build"
+  value       = google_firebase_web_app.app.app_id
+}
+
+output "firebase_web_secret_ids" {
+  description = "Secret Manager IDs holding the Firebase Web App config (→ VITE_FIREBASE_* env vars at build time)"
+  value       = { for k, s in google_secret_manager_secret.firebase_web : k => s.secret_id }
+}

--- a/projects/fantasy-coach/variables.tf
+++ b/projects/fantasy-coach/variables.tf
@@ -9,6 +9,11 @@ variable "region" {
   default     = "australia-southeast1"
 }
 
+variable "domain" {
+  description = "Public custom domain for the SPA — served by Firebase Hosting."
+  type        = string
+}
+
 variable "environment" {
   description = "Deployment environment label (prod, staging, etc.)"
   type        = string

--- a/projects/fantasy-coach/versions.tf
+++ b/projects/fantasy-coach/versions.tf
@@ -6,6 +6,14 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
   }
 
   backend "gcs" {


### PR DESCRIPTION
Replaces closed PR #37 — its base was \`feat/fantasy-coach-scaffold\`, which was auto-deleted when the scaffold PR #36 merged. GitHub won't allow re-targeting a closed PR, hence the re-open as a new one against \`master\`. Content and commits are unchanged from #37 (just rebased onto master).

## Summary
Adds everything needed for the SPA in [lopeztech/fantasy-coach](https://github.com/lopeztech/fantasy-coach) to serve at [\`fantasy.lopezcloud.dev\`](https://fantasy.lopezcloud.dev): Firebase Hosting site + custom domain, Cloudflare DNS, Firebase Auth authorised-domain entry, and Web App config secrets.

## Resources added
- Firebase project + Hosting site (default \`fantasy-coach-lcd.web.app\`) + custom domain \`fantasy.lopezcloud.dev\`
- \`google_identity_platform_config\` with localhost, \`*.firebaseapp.com\`, \`*.web.app\`, \`fantasy.lopezcloud.dev\` authorised for sign-in
- \`google_firebase_web_app\` + 4 Secret Manager secrets (api_key, auth_domain, project_id, app_id) with \`secretAccessor\` for the deployer SA
- Cloudflare CNAME \`fantasy → fantasy-coach-lcd.web.app\`, grey-cloud
- \`roles/firebasehosting.admin\` on the existing deployer SA
- Providers: google-beta, cloudflare (~> 4.0)
- APIs: firebase, firebasehosting, identitytoolkit, secretmanager

## CI wiring
- \`fantasy-coach-plan.yml\` + \`fantasy-coach-apply.yml\` pass \`CLOUDFLARE_API_TOKEN\` into terraform
- \`verify\` job additionally checks the Hosting site + 4 Web secrets

## Out of scope
- Firestore (#15 on app side)
- Vertex AI / Gemini (#22)
- Firebase Auth Google provider Terraform (small follow-up — works via console today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)