### PR TITLE
fix(fantasy-coach): allUsers invoker binding + repair verify step

### DIFF
--- a/.github/workflows/fantasy-coach-apply.yml
+++ b/.github/workflows/fantasy-coach-apply.yml
@@ -105,8 +105,15 @@ jobs:
             gcloud run services describe fantasy-coach-api --project="$PROJECT_ID" --region="$REGION"
 
           echo "── Firebase Hosting ──"
-          check "Hosting site: fantasy-coach-lcd" \
-            gcloud firebase hosting sites describe fantasy-coach-lcd --project="$PROJECT_ID"
+          # gcloud has no `firebase hosting sites describe` subcommand; hit
+          # the Firebase Hosting REST API directly. A 200 proves the site
+          # exists and our token has permission to read it.
+          check "Hosting site: fantasy-coach-lcd" bash -c '
+            STATUS=$(curl -sS -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+              "https://firebasehosting.googleapis.com/v1beta1/projects/'"$PROJECT_ID"'/sites/'"$PROJECT_ID"'")
+            [ "$STATUS" = "200" ]
+          '
 
           echo "── Secret Manager (Firebase Web config) ──"
           for s in firebase-web-api-key firebase-web-auth-domain firebase-web-project-id firebase-web-app-id; do

--- a/projects/fantasy-coach/cloudrun.tf
+++ b/projects/fantasy-coach/cloudrun.tf
@@ -94,6 +94,34 @@ resource "google_cloud_run_v2_service" "api" {
   ]
 }
 
-# No allUsers invoker — auth wiring lives in #17. For now the service is
-# reachable only via identity tokens (Google-signed), which is what the
-# deploy workflow uses for its /healthz smoke test.
+# ── Public-access binding for the Cloud Run API ──────────────────────────────
+# The SPA at fantasy.lopezcloud.dev calls this service directly from the
+# browser. Browsers can't mint Google-signed OAuth2 ID tokens, so Cloud Run's
+# IAM layer can't gate the request — auth happens one level in, at
+# FirebaseAuthMiddleware (src/fantasy_coach/auth.py), which rejects any
+# non-/healthz request missing a valid Firebase ID token with 401.
+#
+# ── One-time manual bootstrap (per project) ──────────────────────────────────
+# The organisation's iam.allowedPolicyMemberDomains constraint blocks
+# allUsers bindings by default. Override it once at the project level with
+# an org admin's own credentials — roles/orgpolicy.policyAdmin isn't
+# grantable at the project level, so neither terraform nor the deployer SA
+# can apply it:
+#
+#   cat > /tmp/allow-public.yaml <<'EOF'
+#   name: projects/fantasy-coach-lcd/policies/iam.allowedPolicyMemberDomains
+#   spec:
+#     rules:
+#     - allowAll: true
+#   EOF
+#   gcloud org-policies set-policy /tmp/allow-public.yaml
+#
+# Once the constraint is lifted, terraform owns the binding below. Same
+# pattern as finance-doctor's functions_public_access.tf.
+resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}


### PR DESCRIPTION
## Summary
Two small follow-ups from yesterday's rollout:

1. **Codify the \`allUsers → run.invoker\` binding** on \`fantasy-coach-api\`. The SPA at fantasy.lopezcloud.dev can't use Cloud Run IAM to authenticate — browsers can't mint Google-signed OAuth2 ID tokens — so FirebaseAuthMiddleware (one layer in) is the auth gate. Without this binding in Terraform, the next apply could strip it and break the SPA.

2. **Fix the verify step.** \`gcloud firebase hosting sites describe\` isn't a real subcommand — the check always failed, making every apply workflow run red even when the apply step itself succeeded. Replaced with a direct REST call to \`firebasehosting.googleapis.com\`.

## Org-policy override stays manual
The \`iam.allowedPolicyMemberDomains\` constraint blocks allUsers by default. \`roles/orgpolicy.policyAdmin\` isn't grantable at project scope, so neither terraform nor the deployer SA can flip it — an org admin applies the override once per project. Same pattern as finance-doctor's \`functions_public_access.tf\`; the recipe is a comment on the new resource.

## Test plan
- [ ] Plan posts (known repo-wide WIF attribute_condition limitation means the plan CI will fail on PR)
- [ ] Apply succeeds on master
- [ ] Verify step now reports all green (the 1 false-fail on Hosting site vanishes)
- [ ] \`curl https://fantasy-coach-api-pvie5ubapa-ts.a.run.app/predictions\` still 401s via FirebaseAuthMiddleware (no IAM regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)