### PR TITLE
fix(fantasy-coach): ignore container env drift so terraform doesn't wipe runtime vars

### DIFF
--- a/projects/fantasy-coach/cloudrun.tf
+++ b/projects/fantasy-coach/cloudrun.tf
@@ -81,6 +81,12 @@ resource "google_cloud_run_v2_service" "api" {
       # The app-repo deploy workflow rotates the image. Terraform shouldn't
       # churn it back to the placeholder on the next plan.
       template[0].containers[0].image,
+      # The deploy workflow sets runtime env vars (FIREBASE_PROJECT_ID,
+      # STORAGE_BACKEND once #15 lands, etc.) via `gcloud run deploy
+      # --set-env-vars`. Terraform must not reconcile them back to empty on
+      # apply — that would silently disable FirebaseAuthMiddleware and leave
+      # /predictions open. The deploy workflow is the source of truth.
+      template[0].containers[0].env,
       # `client` / `client_version` are set by `gcloud run deploy` and would
       # otherwise show as cosmetic drift on every apply.
       client,


### PR DESCRIPTION
## Summary
Yesterday's applies established a trap: the fantasy-coach deploy workflow sets \`FIREBASE_PROJECT_ID\` via \`gcloud run deploy --set-env-vars\`, but terraform's \`google_cloud_run_v2_service\` doesn't model any env vars — so the next platform-infra apply quietly reconciles them back to empty.

That actually fired today. After PI #40 applied, \`/predictions\` unauth'd returned 500 (SQLite-missing) instead of 401 (middleware-rejects) because \`FirebaseAuthMiddleware\` self-skips when \`FIREBASE_PROJECT_ID\` is unset. The 500 was symptomatic; the real risk is that if SQLite *were* usable, we'd have served predictions to anyone with no token.

## Fix
Add \`template[0].containers[0].env\` to the existing \`ignore_changes\` list on \`google_cloud_run_v2_service.api\`. Same pattern as the \`image\` entry — runtime deploys own it, terraform owns the service shape.

## Prevents regression of
- fantasy-coach#86 (flipped to \`--allow-unauthenticated\` + added FIREBASE_PROJECT_ID)
- future env vars like STORAGE_BACKEND (will land with #15 infra)

## Post-incident state
Already re-triggered \`Deploy to Cloud Run\` on fantasy-coach main; env is restored. This PR prevents the next platform-infra apply from wiping it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)