### PR TITLE
fix(fantasy-coach): right-size Cloud Run — 256Mi memory, pin concurrency + timeout

### DIFF
--- a/projects/fantasy-coach/cloudrun.tf
+++ b/projects/fantasy-coach/cloudrun.tf
@@ -34,6 +34,18 @@ resource "google_cloud_run_v2_service" "api" {
       max_instance_count = 2
     }
 
+    # Right-sized from Cloud Run's 300s default after 13h of post-launch
+    # metrics. Cold-round scrape does ~8 sequential nrl.com fetches, so
+    # 60s is unsafe until fantasy-coach#65 lands and scrape is off-path —
+    # 120s keeps headroom while still cutting 60% off the default.
+    timeout = "120s"
+
+    # Pinned at Cloud Run's default (80). Explicit so TF and the
+    # app-repo deploy workflow can't silently drift apart. Candidate to
+    # revisit (80 → 200) after 30 days of real traffic on what is
+    # mostly an I/O endpoint.
+    max_instance_request_concurrency = 80
+
     containers {
       # Placeholder. First real image is pushed + deployed by the app-repo
       # workflow in lopeztech/fantasy-coach; terraform ignores image drift
@@ -46,8 +58,12 @@ resource "google_cloud_run_v2_service" "api" {
 
       resources {
         limits = {
-          cpu    = "1"
-          memory = "512Mi"
+          cpu = "1"
+          # Halved from 512Mi — observed p99 container RSS stays under
+          # 20 % of 512Mi across 20 revisions. 256Mi still leaves ~2.5×
+          # headroom. Must stay in sync with the deploy-workflow flag in
+          # lopeztech/fantasy-coach — both are the source of truth.
+          memory = "256Mi"
         }
         cpu_idle          = true # throttle CPU when not serving a request
         startup_cpu_boost = true # briefly lift the throttle on cold start


### PR DESCRIPTION
Paired with [lopeztech/fantasy-coach#89](https://github.com/lopeztech/fantasy-coach/pull/89).

## Summary

- \`memory\`: 512Mi → **256Mi** (p99 RSS <20% of 512Mi across 20 revisions; 256Mi still >2.5× headroom).
- \`timeout\`: default 300s → **120s** explicit (60s AC is unsafe until fantasy-coach#65; 120s is still a 60% cut).
- \`max_instance_request_concurrency\`: **pin 80** (Cloud Run default, explicit so TF and the app-repo workflow can't silently diverge).

## Why paired

If we set these on only one side, the other silently drifts:
- TF only: \`gcloud run deploy --memory 512Mi\` in the app-repo workflow overwrites on every push.
- Deploy-workflow only: next \`terraform apply\` widens memory back to 512Mi.

Both PRs land the same values; runtime envs stay covered by the existing \`lifecycle.ignore_changes\` block.

## Test plan

- [ ] \`terraform plan\` on \`projects/fantasy-coach\` shows only the three template fields (timeout, max_instance_request_concurrency, memory) changing.
- [ ] \`terraform apply\` succeeds and the next deploy from fantasy-coach#89 does not surface any drift.
- [ ] Verify the live revision reflects memory=256Mi, timeoutSeconds=120, containerConcurrency=80.

## Out of scope (follow-ups)

- Concurrency from 80 → 200 after 30 days of real traffic.
- Timeout 120s → 60s once fantasy-coach#65 lands (scrape precompute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)