### PR TITLE
feat(fantasy-coach): wire project-wide budget alerts (fantasy-coach#63)

### DIFF
--- a/projects/fantasy-coach/billing.tf
+++ b/projects/fantasy-coach/billing.tf
@@ -1,0 +1,25 @@
+# ── Budget Alerts ─────────────────────────────────────────────────────────────
+# Scale-to-zero + Firestore free tier keep today's costs near $0, but we want
+# a wired-up early-warning path for the moment GCP credits run out. The
+# ``modules/budget`` module (already in use by data-feeder) creates a single
+# project-wide budget with email notifications at 50/80/100 % spend plus
+# forecasted-100 %, satisfying the "simple alarm first, per-SKU dashboards
+# later" approach agreed in fantasy-coach#63.
+#
+# A Looker Studio dashboard + BigQuery billing export is an explicit
+# follow-up. Billing Export → BigQuery has to be enabled at the billing
+# account level (needs ``roles/billing.admin`` on the billing account, which
+# is outside this project's Terraform scope), so it's documented as a manual
+# step in docs/cost.md in the paired lopeztech/fantasy-coach PR rather than
+# attempted here.
+
+module "budget" {
+  source = "../../modules/budget"
+
+  project_id         = var.project_id
+  billing_account    = var.billing_account
+  monthly_budget_usd = var.monthly_budget_usd
+  notification_email = var.notification_email
+
+  depends_on = [google_project_service.apis]
+}


### PR DESCRIPTION
Paired with lopeztech/fantasy-coach#90 (extends \`docs/cost.md\`).

## Summary

- New \`projects/fantasy-coach/billing.tf\` calls the existing \`modules/budget\` (already in use by \`data-feeder\`) with the existing \`monthly_budget_usd\` / \`notification_email\` variables — **$20/month**, **admin@lopezcloud.dev**, thresholds at 50/80/100 % plus forecasted-100 %.

## Why the scope is budget-only

The #63 AC also asks for a Looker Studio dashboard over Billing Export → BigQuery. Enabling billing export requires \`roles/billing.admin\` **on the billing account** (outside this project's Terraform scope — \`roles/billing.admin\` is a billing-account-level role, not project-level). Rather than half-provisioning it, I kept this PR to what Terraform can actually apply and documented the manual enablement step in the paired \`docs/cost.md\`.

## Test plan

- [ ] \`terraform plan\` on \`projects/fantasy-coach\` shows only three new resources: \`module.budget.google_monitoring_notification_channel.budget_email\`, \`module.budget.google_billing_budget.project\`, and the existing data-source resolution.
- [ ] \`terraform apply\` succeeds.
- [ ] An email channel appears in Cloud Monitoring → Alerting → Notification channels.
- [ ] The budget appears in the Billing console with the 50/80/100/forecast rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)