### PR TITLE
fix(fantasy-coach): revert Cloud Run memory to 512Mi — gen2 minimum

### DIFF
--- a/projects/fantasy-coach/cloudrun.tf
+++ b/projects/fantasy-coach/cloudrun.tf
@@ -59,11 +59,14 @@ resource "google_cloud_run_v2_service" "api" {
       resources {
         limits = {
           cpu = "1"
-          # Halved from 512Mi — observed p99 container RSS stays under
-          # 20 % of 512Mi across 20 revisions. 256Mi still leaves ~2.5×
-          # headroom. Must stay in sync with the deploy-workflow flag in
-          # lopeztech/fantasy-coach — both are the source of truth.
-          memory = "256Mi"
+          # gen2 execution environment has a 512Mi minimum enforced by
+          # `gcloud run deploy`. The Cloud Run API accepts smaller values
+          # so a bare `terraform apply` can set 256Mi successfully, but
+          # every subsequent app-repo deploy then fails. Keep at 512Mi to
+          # stay in sync with the deploy workflow; dropping below would
+          # require switching execution_environment to gen1, which costs
+          # us startup-cpu-boost + the newer networking stack.
+          memory = "512Mi"
         }
         cpu_idle          = true # throttle CPU when not serving a request
         startup_cpu_boost = true # briefly lift the throttle on cold start


### PR DESCRIPTION
Paired with [lopeztech/fantasy-coach#91](https://github.com/lopeztech/fantasy-coach/pull/91).

Cloud Run API accepted 256Mi via Terraform (live revision 00025 is still running at 256Mi) but \`gcloud run deploy\` enforces gen2's 512Mi minimum client-side and breaks every future app-repo deploy. Revert TF to 512Mi so TF and the deploy workflow stay aligned.

Dropping to gen1 would unlock sub-512Mi but cost us \`startup_cpu_boost\` + newer networking on a scale-to-zero scrape-heavy service. Not a trade worth the pennies/month. Documented as a follow-up note in fantasy-coach's \`docs/cost.md\`.

Concurrency + timeout pins stay — those were the actual drift-insurance + max-billable-CPU wins from #64.

## Test plan

- [ ] \`terraform apply\` reconciles \`memory: "256Mi"\` back to \`"512Mi"\`; plan should show only this single diff.
- [ ] Next app-repo deploy succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)