### PR TITLE
feat(fantasy-coach): precompute Job + Firestore provisioning (fantasy-coach#65)

### DIFF
--- a/projects/fantasy-coach/firestore.tf
+++ b/projects/fantasy-coach/firestore.tf
@@ -1,0 +1,79 @@
+# ── Firestore ────────────────────────────────────────────────────────────────
+# Shared state between the Cloud Run API and the precompute Job (fantasy-
+# coach#65). The app-repo side (#15) shipped the ``FirestoreRepository`` +
+# ``FirestorePredictionStore`` code; the provisioning that should have
+# accompanied it is caught up here.
+#
+# Uses the project's (default) database because ``FirestoreRepository`` and
+# ``FirestorePredictionStore`` both default to ``database="(default)"``.
+# Regional (australia-southeast1) keeps reads near the Cloud Run service,
+# which is in the same region. Delete protection + PITR are on because
+# losing the match history here means re-running a multi-hour backfill.
+
+resource "google_firestore_database" "default" {
+  project     = var.project_id
+  name        = "(default)"
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
+
+  depends_on = [google_project_service.apis]
+}
+
+# Composite index: ``list_matches(season)`` queries filter on season and
+# order by ``start_time`` then ``match_id``. Firestore auto-creates
+# single-field indexes but requires a composite for the filter+order
+# combination. Without this, the query fails at runtime with
+# "this query requires an index".
+
+resource "google_firestore_index" "matches_by_season" {
+  project    = var.project_id
+  database   = google_firestore_database.default.name
+  collection = "matches"
+
+  fields {
+    field_path = "season"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "start_time"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "match_id"
+    order      = "ASCENDING"
+  }
+}
+
+# Composite index: ``list_matches(season, round)`` — same sort, extra filter.
+# Needed because Firestore can't combine an arbitrary where-filter with an
+# order-by unless a matching composite index exists.
+
+resource "google_firestore_index" "matches_by_season_round" {
+  project    = var.project_id
+  database   = google_firestore_database.default.name
+  collection = "matches"
+
+  fields {
+    field_path = "season"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "round"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "start_time"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "match_id"
+    order      = "ASCENDING"
+  }
+}
+
+# No composite index needed for the ``predictions`` collection —
+# ``FirestorePredictionStore`` reads by document ID (``"{season}-{round}"``),
+# which Firestore resolves without any index at all.

--- a/projects/fantasy-coach/iam.tf
+++ b/projects/fantasy-coach/iam.tf
@@ -38,11 +38,25 @@ resource "google_service_account" "runtime" {
   depends_on = [google_project_service.apis]
 }
 
-# No project-level roles yet — runtime currently only needs to serve /healthz.
-# Future issues add:
-#   - roles/datastore.user            (#15 Firestore)
-#   - roles/secretmanager.secretAccessor (#16 Secret Manager)
-#   - roles/aiplatform.user           (#22 Vertex Gemini)
+# The Cloud Run service + the precompute Job (fantasy-coach#65) both run as
+# this SA. They share the Firestore state (matches Repository + prediction
+# cache) so both need read/write. roles/datastore.user covers both.
+locals {
+  runtime_roles = [
+    "roles/datastore.user", # Firestore read + write — matches + prediction cache
+    # Future issues add:
+    #   - roles/secretmanager.secretAccessor (#16 Secret Manager)
+    #   - roles/aiplatform.user           (#22 Vertex Gemini)
+  ]
+}
+
+resource "google_project_iam_member" "runtime" {
+  for_each = toset(local.runtime_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
 
 # ── Deployer SA — used by GitHub Actions to roll revisions ───────────────────
 
@@ -176,4 +190,19 @@ resource "google_service_account_iam_member" "github_app_wif_binding" {
   service_account_id = google_service_account.github_deployer.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_app.name}/attribute.repository/${var.github_org}/${var.app_github_repo}"
+}
+
+# ── Scheduler-invoker SA (fantasy-coach#65) ──────────────────────────────────
+# Dedicated identity Cloud Scheduler uses to invoke the precompute Job. Kept
+# separate from runtime/deployer so a compromise in Scheduler can only run
+# the Job, not touch anything else. The binding that grants run.invoker on
+# the Job itself lives in scheduler.tf to avoid a resource-ordering loop.
+
+resource "google_service_account" "scheduler" {
+  account_id   = "${local.app_name}-scheduler"
+  display_name = "Fantasy Coach Cloud Scheduler invoker"
+  description  = "Identity Cloud Scheduler uses to trigger the precompute Job"
+  project      = var.project_id
+
+  depends_on = [google_project_service.apis]
 }

--- a/projects/fantasy-coach/main.tf
+++ b/projects/fantasy-coach/main.tf
@@ -18,7 +18,10 @@ locals {
 #   #19 (SPA + Firebase Hosting + custom domain) — adds firebase/hosting/
 #       identitytoolkit/secretmanager. Covers Firebase Auth Google sign-in
 #       from fantasy.lopezcloud.dev and publishing the Web App config.
-# Firestore (#15) and Vertex AI (#22) are still pending their own PRs.
+#   #65 (precompute Job + Firestore) — adds firestore/cloudscheduler. The
+#       app-repo Firestore code (#15) landed before the infra side; this
+#       PR catches up both at once.
+# Vertex AI (#22) is still pending its own PR.
 
 resource "google_project_service" "apis" {
   for_each = toset([
@@ -43,6 +46,9 @@ resource "google_project_service" "apis" {
     "firebasehosting.googleapis.com",
     "identitytoolkit.googleapis.com",
     "secretmanager.googleapis.com",
+    # Added in fantasy-coach#65 (precompute Job + Firestore).
+    "firestore.googleapis.com",
+    "cloudscheduler.googleapis.com",
   ])
 
   project            = var.project_id

--- a/projects/fantasy-coach/scheduler.tf
+++ b/projects/fantasy-coach/scheduler.tf
@@ -1,0 +1,161 @@
+# ── Precompute Cloud Run Job + Scheduler triggers (fantasy-coach#65) ─────────
+# Move the cold-round scrape off the /predictions hot path. Cloud Scheduler
+# fires the Job on Tue + Thu AEST; the Job shares the Cloud Run service's
+# image and runs ``python -m fantasy_coach precompute`` which writes the
+# round's predictions to Firestore. The API becomes a pure cache read.
+#
+# Image rotation: the app-repo deploy workflow updates this Job's image
+# alongside the service on every push (``gcloud run jobs update``), so
+# Terraform ignores image drift with ``lifecycle.ignore_changes`` — same
+# pattern the Cloud Run service uses.
+
+resource "google_cloud_run_v2_job" "precompute" {
+  name     = "${local.app_name}-precompute"
+  location = var.region
+  project  = var.project_id
+
+  template {
+    template {
+      service_account = google_service_account.runtime.email
+      # One-shot per run; fail fast if the scrape takes longer than 10 min.
+      # 8 fixtures × ~10s/fetch = ~80s happy-path; 600s handles slow nrl.com.
+      timeout         = "600s"
+      max_retries     = 1
+
+      containers {
+        # Placeholder. First real image is pushed + deployed by the app-repo
+        # workflow in lopeztech/fantasy-coach; Terraform ignores image
+        # drift (see lifecycle block below).
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+
+        # Override the API's uvicorn entrypoint for batch CLI use. Empty
+        # args → precompute autodetects current year + next upcoming round.
+        command = ["python", "-m", "fantasy_coach", "precompute"]
+
+        env {
+          name  = "FIREBASE_PROJECT_ID"
+          value = var.project_id
+        }
+        env {
+          name  = "STORAGE_BACKEND"
+          value = "firestore"
+        }
+        # FANTASY_COACH_MODEL_PATH relies on the image baking in an artifact.
+        # Today that's ``artifacts/logistic.joblib`` — the training artifact
+        # shipped in the container. Swapping to an ensemble is
+        # fantasy-coach#84's job; this Job inherits whatever the image ships.
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi" # gen2 floor, same as the service
+          }
+        }
+      }
+    }
+  }
+
+  labels = local.labels
+
+  lifecycle {
+    ignore_changes = [
+      # app-repo deploy workflow rotates the image on every push.
+      template[0].template[0].containers[0].image,
+      # Deploy workflow may also set env vars (e.g. a future
+      # FANTASY_COACH_MODEL_PATH switch). Keep them out of Terraform's
+      # reconciliation, same as the service.
+      template[0].template[0].containers[0].env,
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_project_iam_member.runtime,
+  ]
+}
+
+# Scheduler SA needs ``run.invoker`` on the Job (not project-wide) so it
+# can call ``:run`` but nothing else.
+
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoker" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_job.precompute.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+# Two cron entries — one after the weekend to buy lead time, one on Thu
+# morning to catch late team-list changes before Thu-night kickoff. Using
+# the ``Australia/Sydney`` timezone lets Cloud Scheduler handle AEDT/AEST
+# transitions so the cron still fires at the intended local time.
+
+locals {
+  # Cloud Run's run-a-job endpoint (v2 REST). Scheduler hits this with an
+  # OAuth token minted for the scheduler SA.
+  precompute_run_uri = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.precompute.name}:run"
+}
+
+resource "google_cloud_scheduler_job" "precompute_tuesday" {
+  name        = "${local.app_name}-precompute-tue"
+  description = "Precompute next-round predictions — buys ~2 days of lead time before Thu-night kickoff."
+  project     = var.project_id
+  region      = var.region
+  schedule    = "0 9 * * 2"
+  time_zone   = "Australia/Sydney"
+
+  http_target {
+    uri         = local.precompute_run_uri
+    http_method = "POST"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  retry_config {
+    retry_count          = 2
+    max_retry_duration   = "0s"
+    min_backoff_duration = "30s"
+    max_backoff_duration = "300s"
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_cloud_run_v2_job_iam_member.scheduler_invoker,
+  ]
+}
+
+resource "google_cloud_scheduler_job" "precompute_thursday" {
+  name        = "${local.app_name}-precompute-thu"
+  description = "Pre-kickoff precompute — catches late team-list changes between Tue and Thu."
+  project     = var.project_id
+  region      = var.region
+  schedule    = "0 6 * * 4"
+  time_zone   = "Australia/Sydney"
+
+  http_target {
+    uri         = local.precompute_run_uri
+    http_method = "POST"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  retry_config {
+    retry_count          = 2
+    max_retry_duration   = "0s"
+    min_backoff_duration = "30s"
+    max_backoff_duration = "300s"
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_cloud_run_v2_job_iam_member.scheduler_invoker,
+  ]
+}


### PR DESCRIPTION
Paired with lopeztech/fantasy-coach#92 (link updated once opened).

## What this provisions

**Firestore** (catches up fantasy-coach#15's missing infra side — the app-repo code shipped in #15 but the database was never actually created):
- \`(default)\` database in \`australia-southeast1\`, native mode, PITR + delete protection on.
- Composite indexes for the two \`list_matches\` query shapes (\`season\` alone, \`(season, round)\`). Without these the queries fail at runtime.
- Runtime SA gets \`roles/datastore.user\`.

**Cloud Run Job** \`fantasy-coach-precompute\`:
- Reuses the API image. Command override: \`python -m fantasy_coach precompute\`.
- \`lifecycle.ignore_changes\` on the image — the app-repo deploy workflow rotates it via \`gcloud run jobs update\`.
- Task timeout 600s (happy path ~80s; leaves room for slow nrl.com).

**Cloud Scheduler**:
- Dedicated \`fantasy-coach-scheduler\` SA with \`roles/run.invoker\` on the Job resource only.
- Two crons in \`Australia/Sydney\` (auto-handles AEDT/AEST):
  - \`0 9 * * 2\` — Tue 09:00, buys two days of lead time.
  - \`0 6 * * 4\` — Thu 06:00, catches late team-list changes; app-repo side \`--force\`s a re-scrape.

**APIs**: \`firestore.googleapis.com\`, \`cloudscheduler.googleapis.com\`.

## Test plan

- [ ] \`terraform plan\` shows the expected new resources plus the iam.tf/main.tf edits; no drift on existing resources.
- [ ] Apply succeeds. Firestore database appears in console (\`(default)\`, australia-southeast1).
- [ ] Manual run: \`gcloud run jobs execute fantasy-coach-precompute --region=australia-southeast1 --project=fantasy-coach-lcd\` — expect it to autodetect the upcoming round and write predictions to Firestore.
- [ ] After app-repo PR lands, \`/predictions\` returns 200 with cached values (or 503 + retry hint until the first Job run populates the cache).

## Out of scope

- Automated dashboard for scheduler/job health (Cloud Monitoring alerts on failed executions). Worth a follow-up once we see real failures to alert on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)