### PR TITLE
fix(fantasy-coach): grant deployer roles/cloudscheduler.admin

### DIFF
--- a/projects/fantasy-coach/iam.tf
+++ b/projects/fantasy-coach/iam.tf
@@ -94,6 +94,11 @@ locals {
     # Needs .admin rather than .accessor because terraform manages the secret
     # resources themselves, not just reads their latest version.
     "roles/secretmanager.admin",
+    # Create + manage google_cloud_scheduler_job resources (scheduler.tf,
+    # fantasy-coach#65). roles/run.admin doesn't grant cloudscheduler.jobs.*
+    # so TF's first apply failed with 403 — chicken-and-egg, same category
+    # as the firebase/identityplatform grants above.
+    "roles/cloudscheduler.admin",
   ]
 }
 


### PR DESCRIPTION
First apply of lopeztech/platform-infra#45's \`scheduler.tf\` failed with:

\`\`\`
Error creating Job: googleapi: Error 403: The principal lacks IAM permission
\"cloudscheduler.jobs.create\" for the resource
\"projects/fantasy-coach-lcd/locations/australia-southeast1\"
\`\`\`

\`roles/run.admin\` (already held) doesn't imply Cloud Scheduler permissions. Grant \`roles/cloudscheduler.admin\` to match the pattern already used for firebase/identityplatform. Re-applies after merge and the scheduler jobs + IAM binding finish creating on top of the partially-applied state from #45.

## State to expect after this lands

- Firestore DB + indexes already applied from #45.
- IAM memberships for runtime (\`datastore.user\`) and scheduler SA already applied from #45.
- \`google_cloud_run_v2_job.precompute\`: status unknown — check \`terraform state list\`; if present, plan is a no-op, if missing, this apply creates it.
- \`google_cloud_scheduler_job.{tuesday,thursday}\`: failed in #45, this apply creates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)