### PR TITLE
feat(fantasy-coach): model artefact bucket (fantasy-coach#93)

### DIFF
--- a/projects/fantasy-coach/main.tf
+++ b/projects/fantasy-coach/main.tf
@@ -49,6 +49,8 @@ resource "google_project_service" "apis" {
     # Added in fantasy-coach#65 (precompute Job + Firestore).
     "firestore.googleapis.com",
     "cloudscheduler.googleapis.com",
+    # Added in fantasy-coach#93 (model artefact bucket).
+    "storage.googleapis.com",
   ])
 
   project            = var.project_id

--- a/projects/fantasy-coach/models.tf
+++ b/projects/fantasy-coach/models.tf
@@ -1,0 +1,52 @@
+# ── Model artifact bucket (fantasy-coach#93) ─────────────────────────────────
+# Holds trained model artefacts (``.joblib`` blobs) for the Cloud Run
+# precompute Job to download at startup. Decouples model lifecycle from
+# image build/deploy: retraining uploads a new object; no image rebuild.
+#
+# One blob is read at runtime — ``logistic/latest.joblib`` — by
+# ``fantasy_coach.predictions._ensure_model`` on a cache-miss path. Versioning
+# keeps prior objects around so a bad upload can be rolled back with
+# ``gcloud storage cp`` (copy the previous generation back on top of latest).
+#
+# Access model: only the runtime SA reads the bucket (``objectViewer``).
+# Uploads are manual from a developer laptop today (see issue #93 option 3);
+# an automated trainer with upload rights is a future issue.
+
+resource "google_storage_bucket" "models" {
+  name     = "${var.project_id}-models"
+  location = var.region
+  project  = var.project_id
+
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  # Keep prior generations so a bad artefact can be rolled back without
+  # re-training. 30-day noncurrent cleanup keeps the bill flat.
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      with_state                 = "NONCURRENT"
+      num_newer_versions         = 5
+      days_since_noncurrent_time = 30
+    }
+  }
+
+  labels = local.labels
+
+  depends_on = [google_project_service.apis]
+}
+
+# Runtime SA needs to read artefacts at container startup. Service-level
+# grant keeps the blast radius to this one bucket.
+resource "google_storage_bucket_iam_member" "runtime_model_reader" {
+  bucket = google_storage_bucket.models.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/projects/fantasy-coach/outputs.tf
+++ b/projects/fantasy-coach/outputs.tf
@@ -62,3 +62,15 @@ output "firebase_web_secret_ids" {
   description = "Secret Manager IDs holding the Firebase Web App config (→ VITE_FIREBASE_* env vars at build time)"
   value       = { for k, s in google_secret_manager_secret.firebase_web : k => s.secret_id }
 }
+
+# ── Model artefact bucket (fantasy-coach#93) ────────────────────────────────
+
+output "models_bucket_name" {
+  description = "GCS bucket holding trained model artefacts (precompute Job downloads from here)"
+  value       = google_storage_bucket.models.name
+}
+
+output "models_bucket_latest_logistic_uri" {
+  description = "Canonical gs:// URI of the logistic artefact the Job downloads at startup (→ FANTASY_COACH_MODEL_GCS_URI)"
+  value       = "gs://${google_storage_bucket.models.name}/logistic/latest.joblib"
+}


### PR DESCRIPTION
## Summary
- New GCS bucket `fantasy-coach-lcd-models` (regional, `australia-southeast1`, versioning on, public-access-prevention enforced).
- Runtime SA gets `roles/storage.objectViewer` on the bucket only — scoped, not project-wide.
- Lifecycle rule keeps the last 5 noncurrent versions for 30 days, then deletes.
- Outputs the bucket name + canonical `gs://.../logistic/latest.joblib` URI so the app repo can pick them up.

## Why
fantasy-coach#93: the Cloud Run precompute Job currently exits 1 on every fire because no model `.joblib` is in the container image. Option 3 from the issue — download from GCS at startup — needs this bucket + IAM before the paired app-repo change can land.

## Out of scope
- Uploading the first `.joblib` (manual `gcloud storage cp` from my laptop once the bucket exists).
- Automated trainer with write access — future issue.
- App-side `_ensure_model` + env-var plumbing on the Job — paired PR in `lopeztech/fantasy-coach`.

## Test plan
- [ ] `terraform plan` shows only additive resources (bucket, IAM member, `storage.googleapis.com` API).
- [ ] After merge + apply, `gcloud storage buckets describe gs://fantasy-coach-lcd-models` returns the bucket.
- [ ] `gcloud storage buckets get-iam-policy gs://fantasy-coach-lcd-models` lists runtime SA with `objectViewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)