### PR TITLE
fix(fantasy-coach): models bucket lifecycle with_state = ARCHIVED

### DIFF
--- a/projects/fantasy-coach/models.tf
+++ b/projects/fantasy-coach/models.tf
@@ -32,7 +32,9 @@ resource "google_storage_bucket" "models" {
       type = "Delete"
     }
     condition {
-      with_state                 = "NONCURRENT"
+      # ARCHIVED = noncurrent (non-live) object versions — the GCS API term
+      # for what versioning produces when an object is overwritten.
+      with_state                 = "ARCHIVED"
       num_newer_versions         = 5
       days_since_noncurrent_time = 30
     }


### PR DESCRIPTION
## Summary
Fix for the apply that failed on #47 merge: `with_state = \"NONCURRENT\"` isn't a valid GCS lifecycle condition value — the API calls noncurrent versions `ARCHIVED`. Same intent: delete noncurrent generations once there are 5 newer and the old one is 30 days old.

## Why
platform-infra apply on 6df961f → 8b28766 errored with `expected lifecycle_rule.0.condition.0.with_state to be one of ["LIVE" "ARCHIVED" "ANY" ""], got NONCURRENT`, blocking the `fantasy-coach-lcd-models` bucket creation that lopeztech/fantasy-coach#94 depends on.

## Test plan
- [ ] After merge + apply, `gcloud storage buckets describe gs://fantasy-coach-lcd-models` succeeds.
- [ ] `gcloud storage buckets get-iam-policy gs://fantasy-coach-lcd-models` shows runtime SA with `objectViewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)