### PR TITLE
fix(fantasy-coach): placeholder secret version unblocks retrain Job create (#107)

### DIFF
--- a/projects/fantasy-coach/retrain.tf
+++ b/projects/fantasy-coach/retrain.tf
@@ -64,6 +64,25 @@ resource "google_secret_manager_secret_iam_member" "retrain_token_access" {
   member    = "serviceAccount:${google_service_account.retrain.email}"
 }
 
+# Cloud Run validates ``secret_key_ref`` at Job creation and refuses to
+# point at an empty secret — ``version = "latest"`` requires at least one
+# version to exist. This placeholder version is created once so the Job
+# can be provisioned before the real PAT is loaded. The real PAT is added
+# manually via ``gcloud secrets versions add`` (see PR body); that creates
+# a new version that becomes ``latest``, and ``ignore_changes`` keeps
+# Terraform from reconciling the placeholder back on top.
+resource "google_secret_manager_secret_version" "github_model_drift_token_placeholder" {
+  secret      = google_secret_manager_secret.github_model_drift_token.id
+  secret_data = "placeholder-rotate-me-via-gcloud-secrets-versions-add"
+
+  lifecycle {
+    ignore_changes = [
+      secret_data,
+      enabled,
+    ]
+  }
+}
+
 # Deployer SA also needs secret accessor so the CI deploy workflow's image
 # rotation step (which applies env vars) can read it when mounting to the
 # Job — not strictly required today (mounting is value-by-reference, resolved
@@ -154,6 +173,7 @@ resource "google_cloud_run_v2_job" "retrain" {
     google_project_iam_member.retrain_firestore,
     google_storage_bucket_iam_member.retrain_models_admin,
     google_secret_manager_secret_iam_member.retrain_token_access,
+    google_secret_manager_secret_version.github_model_drift_token_placeholder,
   ]
 }
 


### PR DESCRIPTION
## Summary

Hotfix for [#50](https://github.com/lopeztech/platform-infra/pull/50)'s apply failure. First apply got 7/8 resources created but `google_cloud_run_v2_job.retrain` bounced with:

```
spec.template.spec.containers[0].env[3].value_from.secret_key_ref.name:
Secret .../secrets/github-model-drift-token/versions/latest was not found
```

Cloud Run validates the secret reference at Job creation; `version = "latest"` requires at least one version to exist. The secret was intentionally a shell (PAT value loaded manually) — that pattern works on other clouds but not here.

## Fix

Add a TF-managed placeholder version with `ignore_changes = [secret_data, enabled]` so:

1. Apply succeeds — the Job can resolve `latest` at create time.
2. User rotates in the real PAT via `gcloud secrets versions add` — that creates a new version which becomes `latest`; TF doesn't reconcile.
3. Retrain's graceful-degradation path means the placeholder never becomes harmful — an invalid PAT hits 401 from the GitHub API, `open_github_model_drift_issue` logs + returns None; drift report is still written to Firestore.

## Test plan

- [ ] `terraform apply` on merge — expect to create `google_secret_manager_secret_version.github_model_drift_token_placeholder` + the three resources that previously bounced (Job, scheduler_invoker binding, Monday Scheduler).
- [ ] `gcloud secrets versions add github-model-drift-token --project=fantasy-coach-lcd --data-file=<real-pat-file>` loads the real PAT.
- [ ] Manual Job trigger: `gcloud run jobs execute fantasy-coach-retrain --region australia-southeast1 --project fantasy-coach-lcd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)