### PR TITLE
feat(home-plant-tracker): PR-scoped read-only WIF for terraform plan

### DIFF
--- a/.github/workflows/home-plant-tracker-plan.yml
+++ b/.github/workflows/home-plant-tracker-plan.yml
@@ -32,10 +32,13 @@ jobs:
           key: terraform-providers-${{ hashFiles('projects/home-plant-tracker/.terraform.lock.hcl') }}
           restore-keys: terraform-providers-
 
+      # PR plans auth as the read-only planner SA via a PR-scoped WIF provider.
+      # Fallback to the deployer secrets lets this workflow keep running while
+      # the new planner resources are being applied for the first time.
       - uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ secrets.HOME_PLANT_TRACKER_WIF_PROVIDER }}
-          service_account: ${{ secrets.HOME_PLANT_TRACKER_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.HOME_PLANT_TRACKER_PLANNER_WIF_PROVIDER || secrets.HOME_PLANT_TRACKER_WIF_PROVIDER }}
+          service_account: ${{ secrets.HOME_PLANT_TRACKER_PLANNER_SA_EMAIL || secrets.HOME_PLANT_TRACKER_SA_EMAIL }}
 
       - name: Terraform Init
         run: |
@@ -44,6 +47,8 @@ jobs:
             -backend-config="prefix=terraform/state/home-plant-tracker/${{ env.TF_ENV }}" \
             -input=false
 
+      # -lock=false: planner SA only has objectViewer on the state bucket, so
+      # it can't create/delete the lock object. Safe for plan (read-only).
       - name: Terraform Plan
         id: plan
         env:
@@ -55,6 +60,7 @@ jobs:
             -var="function_source_object=${{ secrets.HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT }}" \
             -var="billing_account=${{ secrets.BILLING_ACCOUNT_ID }}" \
             -input=false \
+            -lock=false \
             -no-color \
             -out=tfplan 2>&1 | tee plan.txt
           echo "exitcode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT

--- a/projects/home-plant-tracker/iam.tf
+++ b/projects/home-plant-tracker/iam.tf
@@ -161,3 +161,68 @@ resource "google_storage_bucket_iam_member" "deployer_function_source_writer" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.github_deployer.email}"
 }
+
+# ── Service Account — GitHub Actions Planner (PR read-only) ──────────────────
+# Read-only SA used by `terraform plan` on PR branches. The deployer SA above
+# is write-capable and locked to master; this SA is intentionally scoped to
+# viewer-level so a rogue PR workflow cannot mutate GCP state.
+
+resource "google_service_account" "github_planner" {
+  account_id   = "${local.app_name}-planner"
+  display_name = "Plant Tracker Terraform Planner (PR)"
+  description  = "Read-only SA for terraform plan on PR branches"
+  project      = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+locals {
+  planner_roles = [
+    "roles/viewer",                       # Broad read for resource refresh
+    "roles/iam.securityReviewer",         # Full IAM policy read (viewer misses some)
+    "roles/secretmanager.secretAccessor", # Drift detection on google_secret_manager_secret_version
+  ]
+}
+
+resource "google_project_iam_member" "planner" {
+  for_each = toset(local.planner_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.github_planner.email}"
+}
+
+# ── WIF provider for PR-branch terraform plan ─────────────────────────────────
+# Same pool as the deployer provider, but gated on event_name == 'pull_request'
+# and bound to the read-only planner SA. The plan workflow uses this provider;
+# the apply workflow continues to use github-provider (master-only + deployer).
+
+resource "google_iam_workload_identity_pool_provider" "github_pr" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-pr-provider"
+  display_name                       = "GitHub OIDC (PR plan)"
+  project                            = var.project_id
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.ref"        = "assertion.ref"
+    "attribute.event_name" = "assertion.event_name"
+  }
+
+  attribute_condition = "assertion.repository == '${var.github_org}/${var.github_repo}' && assertion.event_name == 'pull_request'"
+}
+
+# Only the planner SA can be impersonated from this provider's principal set;
+# the deployer binding above uses the same principalSet but lives on a
+# different provider, so event_name routing is what picks the SA.
+resource "google_service_account_iam_member" "github_pr_wif_binding" {
+  service_account_id = google_service_account.github_planner.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_org}/${var.github_repo}"
+}

--- a/projects/home-plant-tracker/outputs.tf
+++ b/projects/home-plant-tracker/outputs.tf
@@ -43,6 +43,21 @@ output "service_account_email" {
   value       = google_service_account.github_deployer.email
 }
 
+output "pr_workload_identity_provider" {
+  description = "WIF provider for PR-branch terraform plan — set as HOME_PLANT_TRACKER_PLANNER_WIF_PROVIDER in GitHub Secrets"
+  value       = google_iam_workload_identity_pool_provider.github_pr.name
+}
+
+output "planner_service_account_email" {
+  description = "Read-only planner SA email — set as HOME_PLANT_TRACKER_PLANNER_SA_EMAIL in GitHub Secrets"
+  value       = google_service_account.github_planner.email
+}
+
+output "planner_state_bucket_grant" {
+  description = "One-time manual step: grant the planner SA read on the state bucket (state bucket lives in a different project, so can't be managed here)"
+  value       = "gsutil iam ch serviceAccount:${google_service_account.github_planner.email}:roles/storage.objectViewer gs://platform-infra-lcd-tf-state"
+}
+
 output "artifact_registry_repo" {
   description = "Artifact Registry repo URL for Docker pushes"
   value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}"
@@ -72,12 +87,14 @@ output "ml_data_bucket" {
 output "github_secrets" {
   description = "Copy these values into your GitHub repository secrets for lopeztech/platform-infra"
   value = {
-    HOME_PLANT_TRACKER_WIF_PROVIDER = google_iam_workload_identity_pool_provider.github.name
-    HOME_PLANT_TRACKER_SA_EMAIL     = google_service_account.github_deployer.email
-    ARTIFACT_REGISTRY_REPO          = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}"
-    VITE_API_BASE_URL               = "https://${google_api_gateway_gateway.app.default_hostname}"
-    VITE_GOOGLE_CLIENT_ID           = "(set manually — see iap.tf for instructions)"
-    VITE_API_KEY                    = "(run: terraform output -raw api_key)"
+    HOME_PLANT_TRACKER_WIF_PROVIDER         = google_iam_workload_identity_pool_provider.github.name
+    HOME_PLANT_TRACKER_SA_EMAIL             = google_service_account.github_deployer.email
+    HOME_PLANT_TRACKER_PLANNER_WIF_PROVIDER = google_iam_workload_identity_pool_provider.github_pr.name
+    HOME_PLANT_TRACKER_PLANNER_SA_EMAIL     = google_service_account.github_planner.email
+    ARTIFACT_REGISTRY_REPO                  = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}"
+    VITE_API_BASE_URL                       = "https://${google_api_gateway_gateway.app.default_hostname}"
+    VITE_GOOGLE_CLIENT_ID                   = "(set manually — see iap.tf for instructions)"
+    VITE_API_KEY                            = "(run: terraform output -raw api_key)"
   }
 }
 


### PR DESCRIPTION
## Problem

Every PR's `plan` job fails at the GCP auth step:
```
unauthorized_client — The given credential is rejected by the attribute condition.
```

Root cause: `projects/home-plant-tracker/iam.tf:117` gates the WIF provider on `assertion.ref == 'refs/heads/master'`. PR branches don't match, so no PR can ever plan. Same pattern on fantasy-coach / finance-doctor / data-feeder — we merge blind every time.

## Fix

Split the WIF surface so PRs get a read-only path, and master keeps the write-capable one:

- **New SA** `plant-tracker-planner@…` — `roles/viewer` + `roles/iam.securityReviewer` + `roles/secretmanager.secretAccessor`. No mutate perms.
- **New WIF provider** `github-pr-provider` on the existing pool, gated on `assertion.event_name == 'pull_request'`. Bound only to the planner SA.
- **Existing** `github-provider` (master → deployer SA) is unchanged. Apply still works exactly as before.
- **Plan workflow** now auths with the planner secrets (falls back to deployer secrets until the new ones are set, so this doesn't regress). Added `-lock=false` because planner only has `objectViewer` on the state bucket.

## Rollout (after merge + apply)

1. Grant planner read on the state bucket — state bucket is in the `platform-infra-lcd` project, can't be managed from here:
   ```
   terraform -chdir=projects/home-plant-tracker output -raw planner_state_bucket_grant
   # → gsutil iam ch serviceAccount:...:roles/storage.objectViewer gs://platform-infra-lcd-tf-state
   ```
2. Set two new GitHub secrets:
   - `HOME_PLANT_TRACKER_PLANNER_WIF_PROVIDER` ← `terraform output -raw pr_workload_identity_provider`
   - `HOME_PLANT_TRACKER_PLANNER_SA_EMAIL` ← `terraform output -raw planner_service_account_email`
3. Open the next PR → plan should actually run and post a diff comment.

If it holds up, the same pattern drops into fantasy-coach / finance-doctor / data-feeder.

## Test plan
- [ ] plan job on *this* PR still fails as expected (pre-existing: new resources don't exist yet)
- [ ] apply on master succeeds and creates the planner SA + PR provider
- [ ] gsutil grant + secrets set
- [ ] Next PR's plan job authenticates and posts a plan comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)