### PR TITLE
feat(home-plant-tracker): register missing routes in API Gateway spec

### DIFF
--- a/projects/home-plant-tracker/iam.tf
+++ b/projects/home-plant-tracker/iam.tf
@@ -178,9 +178,12 @@ resource "google_service_account" "github_planner" {
 
 locals {
   planner_roles = [
-    "roles/viewer",                       # Broad read for resource refresh
-    "roles/iam.securityReviewer",         # Full IAM policy read (viewer misses some)
-    "roles/secretmanager.secretAccessor", # Drift detection on google_secret_manager_secret_version
+    "roles/viewer",                          # Broad read for resource refresh
+    "roles/iam.securityReviewer",            # Full IAM policy read (viewer misses some)
+    "roles/secretmanager.secretAccessor",    # Drift detection on google_secret_manager_secret_version
+    "roles/serviceusage.serviceUsageConsumer", # Required for `serviceusage.services.use` —
+                                             # without it, plan refresh of Firebase project / Storage
+                                             # buckets fails with USER_PROJECT_DENIED.
   ]
 }
 

--- a/projects/home-plant-tracker/openapi.yaml.tpl
+++ b/projects/home-plant-tracker/openapi.yaml.tpl
@@ -17,6 +17,10 @@ securityDefinitions:
     type: apiKey
     name: x-api-key
     in: header
+  plant_api_key:
+    type: apiKey
+    name: x-plant-api-key
+    in: header
 
 x-google-backend:
   address: ${function_url}
@@ -773,6 +777,1299 @@ paths:
     options:
       operationId: corsConfigFloorplan
       summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Profile / persona ──────────────────────────────────────────────────────
+  /profile:
+    get:
+      operationId: getProfile
+      summary: Get user profile (accountType — household / landscaper / both)
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Profile snapshot
+    put:
+      operationId: setProfile
+      summary: Update user profile (accountType)
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              accountType:
+                type: string
+      responses:
+        "200":
+          description: Updated profile
+        "400":
+          description: Invalid accountType
+    options:
+      operationId: corsProfile
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Account ────────────────────────────────────────────────────────────────
+  /account:
+    delete:
+      operationId: deleteAccount
+      summary: Delete the caller's account and all associated data
+      x-google-backend:
+        address: ${function_url}
+        path_translation: APPEND_PATH_TO_ADDRESS
+        jwt_audience: ${function_url}
+        deadline: 60.0
+      security:
+        - api_key: []
+      responses:
+        "204":
+          description: Deleted
+    options:
+      operationId: corsAccount
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /account/export:
+    get:
+      operationId: exportAccount
+      summary: GDPR data export of all account data
+      x-google-backend:
+        address: ${function_url}
+        path_translation: APPEND_PATH_TO_ADDRESS
+        jwt_audience: ${function_url}
+        deadline: 60.0
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Full account export (JSON)
+    options:
+      operationId: corsAccountExport
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /account/trial/start:
+    post:
+      operationId: startTrial
+      summary: Start the 7-day home_pro trial for a new account
+      security:
+        - api_key: []
+      responses:
+        "201":
+          description: Trial started
+        "200":
+          description: Trial already exists
+    options:
+      operationId: corsAccountTrialStart
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Households (multi-user shared access) ──────────────────────────────────
+  /households:
+    get:
+      operationId: listHouseholds
+      summary: List households the caller is a member of
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Households + active selection
+    post:
+      operationId: createHousehold
+      summary: Create a new household
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+      responses:
+        "201":
+          description: Created household
+    options:
+      operationId: corsHouseholds
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /households/current:
+    get:
+      operationId: getCurrentHousehold
+      summary: Get the caller's currently active household
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Active household
+    options:
+      operationId: corsHouseholdsCurrent
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /households/join:
+    post:
+      operationId: joinHousehold
+      summary: Join a household via invite code
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+      responses:
+        "200":
+          description: Joined household
+        "404":
+          description: Invite not found / expired
+    options:
+      operationId: corsHouseholdsJoin
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /households/{householdId}:
+    put:
+      operationId: renameHousehold
+      summary: Rename a household
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+      responses:
+        "200":
+          description: Updated household
+    options:
+      operationId: corsHouseholdById
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /households/{householdId}/switch:
+    post:
+      operationId: switchHousehold
+      summary: Switch the caller's active household
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Switched
+    options:
+      operationId: corsHouseholdSwitch
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /households/{householdId}/invites:
+    post:
+      operationId: createHouseholdInvite
+      summary: Create an invite code for a household
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: false
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+      responses:
+        "201":
+          description: Invite created
+    options:
+      operationId: corsHouseholdInvites
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /households/{householdId}/members/{memberUserId}:
+    put:
+      operationId: setHouseholdMemberRole
+      summary: Update a member's role
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+        - in: path
+          name: memberUserId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+      responses:
+        "200":
+          description: Updated
+    delete:
+      operationId: removeHouseholdMember
+      summary: Remove a member from a household
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+        - in: path
+          name: memberUserId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Removed
+    options:
+      operationId: corsHouseholdMember
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: householdId
+          required: true
+          type: string
+        - in: path
+          name: memberUserId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Properties (landscaper multi-property) ─────────────────────────────────
+  /properties:
+    get:
+      operationId: listProperties
+      summary: List the caller's properties
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Property list
+    post:
+      operationId: createProperty
+      summary: Create a property
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "201":
+          description: Created
+    options:
+      operationId: corsProperties
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /properties/{propertyId}:
+    get:
+      operationId: getProperty
+      summary: Get a property by ID
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: propertyId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Property
+        "404":
+          description: Not found
+    put:
+      operationId: updateProperty
+      summary: Update a property
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: propertyId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "200":
+          description: Updated
+    delete:
+      operationId: archiveProperty
+      summary: Archive a property
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: propertyId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Archived
+    options:
+      operationId: corsPropertyById
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: propertyId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /properties/{propertyId}/restore:
+    post:
+      operationId: restoreProperty
+      summary: Restore an archived property
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: propertyId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Restored
+    options:
+      operationId: corsPropertyRestore
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: propertyId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Team RBAC ──────────────────────────────────────────────────────────────
+  /team:
+    get:
+      operationId: listTeam
+      summary: List landscaper org team members
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Team members
+    options:
+      operationId: corsTeam
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /team/invite:
+    post:
+      operationId: inviteTeamMember
+      summary: Invite a new team member to the landscaper org
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              email:
+                type: string
+              role:
+                type: string
+      responses:
+        "201":
+          description: Invite created
+        "402":
+          description: Quota exceeded
+        "403":
+          description: Not the org owner
+    options:
+      operationId: corsTeamInvite
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /team/accept:
+    post:
+      operationId: acceptTeamInvite
+      summary: Accept a team invite via token
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              token:
+                type: string
+      responses:
+        "200":
+          description: Accepted
+        "404":
+          description: Invite not found / expired
+    options:
+      operationId: corsTeamAccept
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /team/{memberUid}:
+    patch:
+      operationId: updateTeamMember
+      summary: Update a team member's role
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: memberUid
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+      responses:
+        "200":
+          description: Updated
+    delete:
+      operationId: removeTeamMember
+      summary: Remove a team member
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: memberUid
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Removed
+    options:
+      operationId: corsTeamMember
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: memberUid
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /me/orgs:
+    get:
+      operationId: listMyOrgs
+      summary: List the orgs the caller is a member of (own + invited landscaper orgs)
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Org list
+    options:
+      operationId: corsMeOrgs
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Visits (landscaper visit lifecycle) ────────────────────────────────────
+  /visits:
+    get:
+      operationId: listVisits
+      summary: List visits (filterable by status / property)
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Visit list
+    post:
+      operationId: createVisit
+      summary: Schedule a new visit
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "201":
+          description: Created
+    options:
+      operationId: corsVisits
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /visits/{visitId}:
+    get:
+      operationId: getVisit
+      summary: Get a visit by ID
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Visit
+        "404":
+          description: Not found
+    put:
+      operationId: updateVisit
+      summary: Update a scheduled visit
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "200":
+          description: Updated
+    delete:
+      operationId: deleteVisit
+      summary: Delete / cancel a visit
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Deleted
+    options:
+      operationId: corsVisitById
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /visits/{visitId}/check-in:
+    post:
+      operationId: checkInVisit
+      summary: Mark visit check-in (started)
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Checked in
+    options:
+      operationId: corsVisitCheckIn
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /visits/{visitId}/check-out:
+    post:
+      operationId: checkOutVisit
+      summary: Mark visit check-out
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Checked out
+    options:
+      operationId: corsVisitCheckOut
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /visits/{visitId}/complete:
+    post:
+      operationId: completeVisit
+      summary: Mark visit complete with notes / work-done log
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: false
+          schema:
+            type: object
+      responses:
+        "200":
+          description: Completed
+    options:
+      operationId: corsVisitComplete
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: visitId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /visits.ics:
+    get:
+      operationId: visitsIcs
+      summary: Visits calendar feed (iCalendar) — token-authenticated
+      responses:
+        "200":
+          description: iCalendar feed
+        "401":
+          description: Invalid / missing token
+
+  /visits/ics-token:
+    get:
+      operationId: getVisitsIcsToken
+      summary: Get / rotate the iCalendar feed token for the caller
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Token
+    options:
+      operationId: corsVisitsIcsToken
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── API keys (public REST API management) ──────────────────────────────────
+  /api-keys:
+    get:
+      operationId: listApiKeys
+      summary: List the caller's public API keys
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: API key list (hash + prefix only; no secret)
+    post:
+      operationId: createApiKey
+      summary: Create a new public API key (returned plaintext once)
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+      responses:
+        "201":
+          description: Created (with plaintext key)
+        "402":
+          description: Tier upgrade required
+    options:
+      operationId: corsApiKeys
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /api-keys/{keyId}:
+    delete:
+      operationId: revokeApiKey
+      summary: Revoke a public API key
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: keyId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Revoked
+    options:
+      operationId: corsApiKeyById
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: keyId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Public REST API (x-plant-api-key) ──────────────────────────────────────
+  /api/v1/plants:
+    get:
+      operationId: publicListPlants
+      summary: Public API — list plants
+      security:
+        - plant_api_key: []
+      responses:
+        "200":
+          description: Plant list
+        "401":
+          description: Invalid API key
+    options:
+      operationId: corsPublicListPlants
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /api/v1/plants/{plantId}:
+    get:
+      operationId: publicGetPlant
+      summary: Public API — get a plant by ID
+      security:
+        - plant_api_key: []
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Plant
+        "404":
+          description: Not found
+    options:
+      operationId: corsPublicPlantById
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /api/v1/plants/{plantId}/water:
+    post:
+      operationId: publicWaterPlant
+      summary: Public API — log a watering event
+      security:
+        - plant_api_key: []
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Updated plant
+        "404":
+          description: Not found
+    options:
+      operationId: corsPublicWaterPlant
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /api/v1/plants/{plantId}/care-score:
+    get:
+      operationId: publicCareScore
+      summary: Public API — care score for a plant
+      security:
+        - plant_api_key: []
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Care score
+        "402":
+          description: Tier upgrade required
+    options:
+      operationId: corsPublicCareScore
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Climate / hardiness (PR #366) ──────────────────────────────────────────
+  /climate/lookup:
+    get:
+      operationId: climateLookup
+      summary: Köppen climate classification + frost dates from Open-Meteo
+      x-google-backend:
+        address: ${function_url}
+        path_translation: APPEND_PATH_TO_ADDRESS
+        jwt_audience: ${function_url}
+        deadline: 30.0
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Climate classification
+    options:
+      operationId: corsClimateLookup
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /climate/plant-compatibility:
+    get:
+      operationId: climateCompatibility
+      summary: Gemini hardy / tender / unsuitable verdict for a plant + climate
+      x-google-backend:
+        address: ${function_url}
+        path_translation: APPEND_PATH_TO_ADDRESS
+        jwt_audience: ${function_url}
+        deadline: 110.0
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Compatibility verdict
+    options:
+      operationId: corsClimateCompatibility
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Companion planting / raised-bed grids (PR #366) ────────────────────────
+  /companions:
+    get:
+      operationId: getCompanions
+      summary: Companion planting matrix
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Companion data
+    options:
+      operationId: corsCompanions
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /config/beds/{roomId}/compatibility:
+    get:
+      operationId: getBedCompatibility
+      summary: Compatibility overlay for a raised-bed room
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: roomId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: 8-cell neighbourhood compatibility scan
+    options:
+      operationId: corsBedCompatibility
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: roomId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /plants/{plantId}/bed-placement:
+    post:
+      operationId: setBedPlacement
+      summary: Place a plant in a raised-bed grid cell
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "200":
+          description: Placed
+    delete:
+      operationId: removeBedPlacement
+      summary: Remove a plant's bed placement
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Removed
+    options:
+      operationId: corsBedPlacement
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Branding (landscaper white-label) ──────────────────────────────────────
+  /config/branding:
+    get:
+      operationId: getBranding
+      summary: Get business branding (logo, colour, contact info)
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Branding config
+    put:
+      operationId: saveBranding
+      summary: Save business branding
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "200":
+          description: Saved
+        "402":
+          description: Tier upgrade required
+    options:
+      operationId: corsConfigBranding
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Propagations ───────────────────────────────────────────────────────────
+  /propagations:
+    get:
+      operationId: listPropagations
+      summary: List propagations
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Propagation list
+    post:
+      operationId: createPropagation
+      summary: Create a propagation
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "201":
+          description: Created
+    options:
+      operationId: corsPropagations
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /propagations/{propagationId}:
+    put:
+      operationId: updatePropagation
+      summary: Update a propagation
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: propagationId
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "200":
+          description: Updated
+    delete:
+      operationId: deletePropagation
+      summary: Delete a propagation
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: propagationId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Deleted
+    options:
+      operationId: corsPropagationById
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: propagationId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /propagations/{propagationId}/promote:
+    post:
+      operationId: promotePropagation
+      summary: Convert a propagation into an independent plant
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: propagationId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Promoted to plant
+    options:
+      operationId: corsPropagationPromote
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: propagationId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  /propagation/stats:
+    get:
+      operationId: propagationStats
+      summary: Aggregate propagation success-rate stats
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Stats
+    options:
+      operationId: corsPropagationStats
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /plants/{plantId}/lineage:
+    get:
+      operationId: getPlantLineage
+      summary: Ancestors + descendants of a plant (depth ≤ 3, cycle-guarded)
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Lineage tree
+    options:
+      operationId: corsPlantLineage
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── QR / scan public access ────────────────────────────────────────────────
+  /scan/{shortCode}:
+    get:
+      operationId: resolveScan
+      summary: Resolve a QR short-code to a plant (public, no auth)
+      parameters:
+        - in: path
+          name: shortCode
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Plant
+        "404":
+          description: Not found
+
+  /plants/{plantId}/short-code:
+    get:
+      operationId: getPlantShortCode
+      summary: Get / generate the QR short-code for a plant
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Short-code + QR URL
+    options:
+      operationId: corsPlantShortCode
+      summary: CORS preflight
+      parameters:
+        - in: path
+          name: plantId
+          required: true
+          type: string
       responses:
         "204":
           description: CORS preflight


### PR DESCRIPTION
## Summary

The Express backend in \`home-plant-tracker\` has accumulated ~145 routes; only ~22 were declared in this gateway spec. The rest were silently 404-ing at the gateway and surfacing as **\"NetworkError when attempting to fetch\"** in the browser (no CORS headers on the gateway 404). Two screenshots from a recent debug session showed this on **Current household** and **Your API Keys** panels — confirmed via direct \`curl\`:

\`\`\`
GET https://plant-tracker-gateway-prod-16xqsbyu.ts.gateway.dev/households
→ 404 {\"code\":404,\"message\":\"The current request is not defined by this API.\"}
\`\`\`

This pass registers **45 of the highest-impact missing routes** covering everything that's blocking the recently-shipped persona / multi-property / team / visits features.

### Routes added

| Group | Routes | From |
|---|---|---|
| Profile | \`GET / PUT /profile\` | PR #375 (persona) |
| Households | 9 endpoints (list/current/create/join/switch/rename/invites/members CRUD) | PR #356 |
| API keys | \`GET / POST / DELETE /api-keys\` | already shipped |
| Public REST API | \`GET /api/v1/plants\`, \`GET /api/v1/plants/{id}\`, \`POST /api/v1/plants/{id}/water\`, \`GET /api/v1/plants/{id}/care-score\` | already shipped |
| Properties | 6 endpoints (list/create/get/update/archive/restore) | PR #159 |
| Team RBAC | \`GET /team\`, \`POST /team/invite\`, \`POST /team/accept\`, \`PATCH/DELETE /team/{memberUid}\`, \`GET /me/orgs\` | PR #163 |
| Visits | 8 endpoints (CRUD + check-in/out/complete + ICS feed + token) | PR #164 |
| Climate | \`GET /climate/lookup\`, \`GET /climate/plant-compatibility\` | PR #366 |
| Companions / beds | \`GET /companions\`, \`GET /config/beds/{roomId}/compatibility\`, \`POST/DELETE /plants/{id}/bed-placement\` | PR #366 |
| Branding | \`GET / PUT /config/branding\` | landscaper white-label |
| Propagations | CRUD + \`promote\`, \`/propagation/stats\`, \`/plants/{id}/lineage\` | propagation feature |
| QR / scan | \`GET /scan/{shortCode}\`, \`GET /plants/{id}/short-code\` | already shipped |
| Account | \`DELETE /account\`, \`GET /account/export\`, \`POST /account/trial/start\` | already shipped |

### New security definition

\`\`\`yaml
plant_api_key:
  type: apiKey
  name: x-plant-api-key
  in: header
\`\`\`

Used only by the \`/api/v1/*\` public REST surface. Backend looks up the SHA-256 hash of this header in Firestore (\`apiKeyHashes/{hash}\`); the gateway just enforces presence.

### Routes still missing (deferred — none block persona)

Per-plant care-log subresources (measurements / phenology / journal / harvests / soil-tests / amendments / substrate-changes / incidents / treatments / wildlifeObservations / blooms / lifecycle / dormancy / anomaly / health-prediction / seasonal-adjustment / care-score / watering-recommendation / waterings / soil-insight), \`/outbreaks\`, \`/portal/*\`, \`/sit/*\`, \`/sit-sessions\`, \`/export/*\`, \`/import/*\`, \`/ml/*\`, \`/recommend-propagation\`, \`/analyse-with-hint\`, \`/plants/identify\`, \`/species/{name}/cluster\`. Total ~80 routes. They're real features but none block what just shipped — happy to do a follow-up PR.

## Test plan
- [x] \`python3 -c \"yaml.safe_load(open(...))\"\` parses cleanly (67 paths, was 22)
- [ ] Terraform plan in CI shows expected diff on \`google_api_gateway_api_config\`
- [ ] After apply: \`curl https://plant-tracker-gateway-prod-16xqsbyu.ts.gateway.dev/profile\` returns 401 (auth required) instead of 404 (route undefined)
- [ ] After apply: same check for \`/households\`, \`/api-keys\`, \`/visits\`, \`/properties\`, \`/team\`, \`/climate/lookup\`, \`/companions\`, \`/config/branding\`, \`/api/v1/plants\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)