### PR TITLE
feat(home-plant-tracker): register /config/feature-flags routes

### DIFF
--- a/projects/home-plant-tracker/openapi.yaml.tpl
+++ b/projects/home-plant-tracker/openapi.yaml.tpl
@@ -1889,6 +1889,44 @@ paths:
         "204":
           description: CORS preflight
 
+  # ── Feature-flag overrides (workspace admin) ───────────────────────────────
+  /config/feature-flags:
+    get:
+      operationId: getFeatureFlags
+      summary: Get workspace feature-flag overrides (any member)
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Feature-flag overrides + canEdit hint
+    put:
+      operationId: saveFeatureFlags
+      summary: Save workspace feature-flag overrides (admin only)
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              overrides:
+                type: object
+      responses:
+        "200":
+          description: Saved
+        "400":
+          description: Invalid overrides payload
+        "403":
+          description: Forbidden — workspace admin role required
+    options:
+      operationId: corsConfigFeatureFlags
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
   # ── Propagations ───────────────────────────────────────────────────────────
   /propagations:
     get:


### PR DESCRIPTION
## Summary
- Adds `GET` / `PUT` / `OPTIONS` for `/config/feature-flags` to the home-plant-tracker API Gateway spec.
- Pairs with home-plant-tracker PR #381 (admin-only feature visibility toggles). Without this, the new Settings → Features tab can't load or save (gateway 404).
- Admin role enforcement (household owner / landscaper org manager) lives in the Cloud Run handler — the gateway just forwards.

## Test plan
- [x] YAML parses (`python3 -c "yaml.safe_load(...)"`)
- [ ] `home-plant-tracker-plan` workflow succeeds on this PR — review the terraform plan: expect a config update on `google_api_gateway_api_config` + a new `google_api_gateway_gateway` revision; **no** Cloud Run / Firestore changes
- [ ] After merge & apply: `curl -H "x-api-key: $API_KEY" -H "Authorization: Bearer $JWT" https://api.plants.lopezcloud.dev/config/feature-flags` returns `{"overrides":{},"updatedAt":null,"canEdit":<bool>}`
- [ ] In the deployed app: as household owner, open Settings → Features, toggle Branding to "Hidden", save, confirm sidebar updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)