### PR TITLE
feat(home-plant-tracker): global external HTTPS LB + managed cert for api.plants

### DIFF
--- a/projects/home-plant-tracker/dns.tf
+++ b/projects/home-plant-tracker/dns.tf
@@ -13,15 +13,15 @@ resource "cloudflare_record" "app" {
   name    = "plants"
   type    = "CNAME"
   content = "${google_firebase_hosting_site.plant_tracker.site_id}.web.app"
-  proxied = false  # DNS-only — Firebase handles CDN and TLS
+  proxied = false # DNS-only — Firebase handles CDN and TLS
   ttl     = 3600
 }
 
 resource "cloudflare_record" "api" {
   zone_id = data.cloudflare_zone.lopezcloud.id
   name    = "api.plants"
-  type    = "CNAME"
-  content = google_api_gateway_gateway.app.default_hostname
-  proxied = true  # Cloudflare terminates TLS for api.plants.lopezcloud.dev
-  ttl     = 1     # Auto — required when proxied
+  type    = "A"
+  content = google_compute_global_address.api.address
+  proxied = false # DNS-only — GCP LB terminates TLS with a managed cert (see loadbalancer.tf)
+  ttl     = 3600
 }

--- a/projects/home-plant-tracker/loadbalancer.tf
+++ b/projects/home-plant-tracker/loadbalancer.tf
@@ -1,0 +1,90 @@
+# ── Global External HTTPS Load Balancer for api.${var.domain} ────────────────
+#
+# Fronts the API Gateway with a Google-managed cert so that Stripe (and any
+# other strict TLS client) can complete the handshake against
+# api.plants.lopezcloud.dev. Previously the hostname was Cloudflare-proxied
+# CNAME → *.gateway.dev, but Cloudflare's edge had no valid cert for that
+# subdomain so the handshake failed at TLS alert 40. Replacing the proxy with
+# a serverless-NEG → API Gateway LB gives single-vendor managed TLS and drops
+# Cloudflare from the API path (DNS-only A record below).
+
+resource "google_compute_global_address" "api" {
+  name    = "${local.app_name}-api-ip"
+  project = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_compute_region_network_endpoint_group" "api_gateway" {
+  provider              = google-beta
+  name                  = "${local.app_name}-api-gateway-neg"
+  project               = var.project_id
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+
+  serverless_deployment {
+    platform = "apigateway.googleapis.com"
+    resource = google_api_gateway_gateway.app.gateway_id
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_compute_backend_service" "api" {
+  name                  = "${local.app_name}-api-backend"
+  project               = var.project_id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.api_gateway.id
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_compute_url_map" "api" {
+  name            = "${local.app_name}-api-urlmap"
+  project         = var.project_id
+  default_service = google_compute_backend_service.api.id
+}
+
+resource "google_compute_managed_ssl_certificate" "api" {
+  name    = "${local.app_name}-api-cert"
+  project = var.project_id
+
+  managed {
+    domains = ["api.${var.domain}"]
+  }
+
+  # Replacing a managed cert in place fails — Google requires create-before-destroy
+  # so the new cert can be attached to the proxy before the old one is removed.
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_compute_target_https_proxy" "api" {
+  name             = "${local.app_name}-api-https-proxy"
+  project          = var.project_id
+  url_map          = google_compute_url_map.api.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.api.id]
+}
+
+resource "google_compute_global_forwarding_rule" "api" {
+  name                  = "${local.app_name}-api-fr"
+  project               = var.project_id
+  target                = google_compute_target_https_proxy.api.id
+  port_range            = "443"
+  ip_address            = google_compute_global_address.api.address
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  labels = local.labels
+}

--- a/projects/home-plant-tracker/outputs.tf
+++ b/projects/home-plant-tracker/outputs.tf
@@ -74,7 +74,7 @@ output "api_public_url" {
 }
 
 output "api_lb_ip" {
-  description = "Static anycast IP fronting api.${var.domain}. The Cloudflare A record is managed by Terraform; this is exposed for diagnostics (dig / openssl s_client)."
+  description = "Static anycast IP fronting the API hostname. The Cloudflare A record is managed by Terraform; this is exposed for diagnostics (dig / openssl s_client)."
   value       = google_compute_global_address.api.address
 }
 

--- a/projects/home-plant-tracker/outputs.tf
+++ b/projects/home-plant-tracker/outputs.tf
@@ -68,6 +68,16 @@ output "api_gateway_url" {
   value       = "https://${google_api_gateway_gateway.app.default_hostname}"
 }
 
+output "api_public_url" {
+  description = "Public API URL served via the global external HTTPS LB — preferred VITE_API_BASE_URL once the managed cert is ACTIVE"
+  value       = "https://api.${var.domain}"
+}
+
+output "api_lb_ip" {
+  description = "Static anycast IP fronting api.${var.domain}. The Cloudflare A record is managed by Terraform; this is exposed for diagnostics (dig / openssl s_client)."
+  value       = google_compute_global_address.api.address
+}
+
 output "api_key" {
   description = "API key for the Plant Tracker API — set as VITE_API_KEY in GitHub Secrets and .env.local"
   value       = google_apikeys_key.app.key_string


### PR DESCRIPTION
## Summary
- Adds a global external HTTPS load balancer (serverless NEG → API Gateway) fronting `api.plants.lopezcloud.dev`, with a Google-managed cert.
- Flips the Cloudflare `api.plants` record from proxied CNAME → DNS-only A pointing at the new LB IP, dropping Cloudflare from the API TLS path.
- Unblocks Stripe webhook delivery: Cloudflare's edge had no valid cert for this hostname so handshakes failed at TLS alert 40. Frontend keeps working off the gateway's `*.gateway.dev` URL until the new cert is `ACTIVE`.

## Sequencing on apply
1. Terraform creates the LB + IP + cert (cert enters `PROVISIONING`).
2. Terraform updates the Cloudflare record to point at the new IP (DNS-only).
3. Google validates and provisions the managed cert (~10–30 min) once DNS resolves to the LB.
4. Verify: `openssl s_client -connect api.plants.lopezcloud.dev:443 -brief </dev/null` and `curl -fsS https://api.plants.lopezcloud.dev/health`.
5. Stripe webhook URL stays as `https://api.plants.lopezcloud.dev/billing/webhook`; resend the failed events after the cert is green.

## Test plan
- [ ] `home-plant-tracker — Plan` workflow runs clean on the PR (no drift outside the new LB resources + DNS swap).
- [ ] After apply: `gcloud compute ssl-certificates describe plant-tracker-api-cert --global --format='value(managed.status)'` reports `ACTIVE`.
- [ ] `openssl s_client -connect api.plants.lopezcloud.dev:443 -brief </dev/null` completes the handshake with `Verification: OK`.
- [ ] `curl -fsS https://api.plants.lopezcloud.dev/health` returns 200.
- [ ] Stripe webhook test event delivers successfully (or replay a previously-failed delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)