### PR TITLE
feat(home-plant-tracker): register /gifts and /rebates routes in API Gateway spec

### DIFF
--- a/projects/home-plant-tracker/openapi.yaml.tpl
+++ b/projects/home-plant-tracker/openapi.yaml.tpl
@@ -3861,6 +3861,107 @@ paths:
         "200":
           description: Watered
 
+  # ── Gift cards ─────────────────────────────────────────────────────────────
+  /gifts/mine:
+    get:
+      operationId: listMyGifts
+      summary: List gift cards purchased or redeemed by the caller
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Gift card list
+    options:
+      operationId: corsGiftsMine
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /gifts/purchase:
+    post:
+      operationId: purchaseGift
+      summary: Purchase a gift card (creates a Stripe checkout session)
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+      responses:
+        "200":
+          description: Checkout session
+        "402":
+          description: Payment required / billing disabled
+    options:
+      operationId: corsGiftsPurchase
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /gifts/redeem:
+    post:
+      operationId: redeemGift
+      summary: Redeem a gift card code against the caller's account
+      security:
+        - api_key: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+      responses:
+        "200":
+          description: Redeemed
+        "400":
+          description: Invalid or already-redeemed code
+        "404":
+          description: Code not found
+    options:
+      operationId: corsGiftsRedeem
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  # ── Rebates ────────────────────────────────────────────────────────────────
+  /rebates/categories:
+    get:
+      operationId: listRebateCategories
+      summary: List rebate categories (public — no auth)
+      responses:
+        "200":
+          description: Rebate category list
+    options:
+      operationId: corsRebatesCategories
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
+  /rebates/matches:
+    get:
+      operationId: listRebateMatches
+      summary: List rebates matching the caller's plants / location
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: Rebate match list
+    options:
+      operationId: corsRebatesMatches
+      summary: CORS preflight
+      responses:
+        "204":
+          description: CORS preflight
+
 definitions:
   Plant:
     type: object


### PR DESCRIPTION
## Summary
- Adds five backend routes that the function already implements but the gateway spec didn't declare, so they were 404-ing at the gateway:
  - `GET /gifts/mine`, `POST /gifts/purchase`, `POST /gifts/redeem` (api_key)
  - `GET /rebates/categories` (public)
  - `GET /rebates/matches` (api_key)
- Each path also gets the standard `OPTIONS` CORS preflight to match neighbouring routes.

## Test plan
- [ ] `home-plant-tracker — Plan` workflow runs clean; only the api_config / gateway are replaced/updated (expected, because the OpenAPI hash drives `api_config_id`).
- [ ] After apply: `curl -fsS -H "x-api-key: $VITE_API_KEY" https://api.plants.lopezcloud.dev/gifts/mine` returns 200 instead of 404.
- [ ] `curl -fsS https://api.plants.lopezcloud.dev/rebates/categories` returns 200 without an API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)