### PR TITLE
fix(ci): resolve home-plant-tracker function source dynamically from GCS

### DIFF
--- a/.github/workflows/home-plant-tracker-apply.yml
+++ b/.github/workflows/home-plant-tracker-apply.yml
@@ -26,6 +26,7 @@ jobs:
       TF_DIR: projects/home-plant-tracker
       TF_ENV: prod
       TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+      FN_SOURCE_BUCKET: home-plant-tracker-lcd-fn-source-prod
     steps:
       - uses: actions/checkout@v6
 
@@ -45,6 +46,40 @@ jobs:
           workload_identity_provider: ${{ secrets.HOME_PLANT_TRACKER_WIF_PROVIDER }}
           service_account: ${{ secrets.HOME_PLANT_TRACKER_SA_EMAIL }}
 
+      - uses: google-github-actions/setup-gcloud@v3
+
+      # Resolve the Cloud Function source ZIP. Resolution order:
+      #   1. workflow_dispatch input (explicit override)
+      #   2. most-recent .zip in the source bucket (self-healing — survives
+      #      home-plant-tracker repo uploading without coordinating a secret
+      #      bump, and the 30-day GCS lifecycle on this bucket)
+      #   3. HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT secret (bootstrap
+      #      fallback for when the bucket is empty)
+      - name: Resolve function source object
+        id: source
+        run: |
+          set -euo pipefail
+          OBJ="${{ inputs.function_source_object }}"
+          if [ -z "$OBJ" ]; then
+            OBJ=$(gcloud storage objects list "gs://${FN_SOURCE_BUCKET}" \
+                    --format="value(name)" \
+                    --sort-by="~timeCreated" \
+                    --limit=20 2>/dev/null \
+                  | grep -E '\.zip$' \
+                  | head -1 \
+                  || true)
+          fi
+          if [ -z "$OBJ" ]; then
+            OBJ="${{ secrets.HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT }}"
+            echo "::warning::Bucket gs://${FN_SOURCE_BUCKET} has no .zip objects; falling back to secret."
+          fi
+          if [ -z "$OBJ" ]; then
+            echo "::error::No function source ZIP found in bucket and no fallback secret set."
+            exit 1
+          fi
+          echo "Resolved function_source_object=${OBJ}"
+          echo "object=${OBJ}" >> "$GITHUB_OUTPUT"
+
       - name: Terraform Init
         run: |
           terraform -chdir=${{ env.TF_DIR }} init \
@@ -59,7 +94,7 @@ jobs:
           terraform -chdir=${{ env.TF_DIR }} apply \
             -var-file="environments/${{ env.TF_ENV }}/terraform.tfvars" \
             -var="ml_admin_token=${{ secrets.ML_ADMIN_TOKEN }}" \
-            -var="function_source_object=${{ inputs.function_source_object || secrets.HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT }}" \
+            -var="function_source_object=${{ steps.source.outputs.object }}" \
             -var="billing_account=${{ secrets.BILLING_ACCOUNT_ID }}" \
             -input=false \
             -auto-approve \

--- a/.github/workflows/home-plant-tracker-plan.yml
+++ b/.github/workflows/home-plant-tracker-plan.yml
@@ -18,6 +18,7 @@ jobs:
       TF_DIR: projects/home-plant-tracker
       TF_ENV: prod
       TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+      FN_SOURCE_BUCKET: home-plant-tracker-lcd-fn-source-prod
     steps:
       - uses: actions/checkout@v6
 
@@ -40,6 +41,33 @@ jobs:
           workload_identity_provider: ${{ secrets.HOME_PLANT_TRACKER_PLANNER_WIF_PROVIDER || secrets.HOME_PLANT_TRACKER_WIF_PROVIDER }}
           service_account: ${{ secrets.HOME_PLANT_TRACKER_PLANNER_SA_EMAIL || secrets.HOME_PLANT_TRACKER_SA_EMAIL }}
 
+      - uses: google-github-actions/setup-gcloud@v3
+
+      # Resolve the latest function source ZIP from the bucket so the plan
+      # reflects reality. Falls back to the secret if the bucket is empty.
+      # See apply workflow for the full rationale.
+      - name: Resolve function source object
+        id: source
+        run: |
+          set -euo pipefail
+          OBJ=$(gcloud storage objects list "gs://${FN_SOURCE_BUCKET}" \
+                  --format="value(name)" \
+                  --sort-by="~timeCreated" \
+                  --limit=20 2>/dev/null \
+                | grep -E '\.zip$' \
+                | head -1 \
+                || true)
+          if [ -z "$OBJ" ]; then
+            OBJ="${{ secrets.HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT }}"
+            echo "::warning::Bucket gs://${FN_SOURCE_BUCKET} has no .zip objects; falling back to secret."
+          fi
+          if [ -z "$OBJ" ]; then
+            echo "::error::No function source ZIP found in bucket and no fallback secret set."
+            exit 1
+          fi
+          echo "Resolved function_source_object=${OBJ}"
+          echo "object=${OBJ}" >> "$GITHUB_OUTPUT"
+
       - name: Terraform Init
         run: |
           terraform -chdir=${{ env.TF_DIR }} init \
@@ -57,7 +85,7 @@ jobs:
           terraform -chdir=${{ env.TF_DIR }} plan \
             -var-file="environments/${{ env.TF_ENV }}/terraform.tfvars" \
             -var="ml_admin_token=${{ secrets.ML_ADMIN_TOKEN }}" \
-            -var="function_source_object=${{ secrets.HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT }}" \
+            -var="function_source_object=${{ steps.source.outputs.object }}" \
             -var="billing_account=${{ secrets.BILLING_ACCOUNT_ID }}" \
             -input=false \
             -lock=false \


### PR DESCRIPTION
## Summary
- Both the plan and apply workflows now resolve the Cloud Function source ZIP by listing the source bucket (`gs://home-plant-tracker-lcd-fn-source-prod`) and picking the most-recently-created `.zip`, instead of reading a manually-coordinated GitHub Actions secret.
- The secret stays as a bootstrap fallback (for the empty-bucket case); the `workflow_dispatch` input still wins as an explicit override.

## Why
Two failure modes the old design couldn't dodge:
1. **Missed coordination.** The home-plant-tracker app repo had to bump `HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT` after every upload. Any miss left the next platform-infra apply pointing at the wrong (often nonexistent) object.
2. **30-day GCS lifecycle.** The source bucket auto-deletes objects after 30 days. A platform-infra apply that ran weeks after the last secret update would 404 trying to clone the referenced ZIP — which is exactly what hit PR #58's apply earlier today.

The newest object in the bucket is always real and always the one we want.

## Resolution order
1. `workflow_dispatch` input (manual override) — apply only, unchanged
2. Newest `.zip` in the source bucket sorted by `timeCreated desc`
3. `HOME_PLANT_TRACKER_FUNCTION_SOURCE_OBJECT` secret (bootstrap fallback)

## Test plan
- [ ] Plan workflow runs clean on this PR and the "Resolved function_source_object=…" log line shows a real bucket object.
- [ ] After merge, the apply-on-push to master succeeds without needing a `workflow_dispatch` rerun.
- [ ] Once landed, the home-plant-tracker app repo's CI can stop updating the secret on every upload (it just needs to upload to the bucket). Tracking that follow-up in the app repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)