### PR TITLE
feat(fantasy-coach): grant runtime SA access to odds-api-key

### DIFF
--- a/projects/fantasy-coach/odds_api_secret.tf
+++ b/projects/fantasy-coach/odds_api_secret.tf
@@ -1,0 +1,20 @@
+# ── odds-api-key Secret Manager access (fantasy-coach#280) ───────────────────
+# Grants the runtime SA read access to the the-odds-api.com key used by the
+# precompute Cloud Run Job to fetch NRL totals (over/under) lines for the
+# Betting Tips card.
+#
+# The secret itself is created out-of-band via ``gcloud secrets create
+# odds-api-key`` because its value is a third-party API key that should never
+# enter Terraform state. Rotation: ``gcloud secrets versions add`` ; Cloud Run
+# picks up the new ``:latest`` version on the next revision roll (see
+# docs/secrets.md in the app repo).
+#
+# Only the precompute Job uses the key. The API service never reads it, so no
+# grant is needed there.
+
+resource "google_secret_manager_secret_iam_member" "odds_api_key_runtime" {
+  project   = var.project_id
+  secret_id = "odds-api-key"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}


### PR DESCRIPTION
Paired with [lopeztech/fantasy-coach#280](https://github.com/lopeztech/fantasy-coach/issues/280) (Betting Tips).

## Summary

- New IAM binding: `roles/secretmanager.secretAccessor` on the existing `odds-api-key` Secret Manager secret, granted to `fantasy-coach-runtime`.
- Secret itself is **not** managed by Terraform — its value is a third-party API key that should never enter TF state. Created out-of-band via `gcloud secrets create odds-api-key`.

The precompute Cloud Run Job (the only consumer) will read it via `--set-secrets FANTASY_COACH_ODDS_API_KEY=odds-api-key:latest`, wired in by the app-repo's `deploy.yml` in a paired PR. Without that grant the next Cloud Run revision roll would fail to start the Job with a permission-denied error.

## Test plan

- [ ] `terraform plan` shows a single resource create: `google_secret_manager_secret_iam_member.odds_api_key_runtime`.
- [ ] `terraform apply` succeeds on merge.
- [ ] After merge, the paired fantasy-coach PR's deploy successfully rolls a Job revision that references the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)